### PR TITLE
New multiplayer mode - Project Packages Upgrade and Optimization

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Get version info
         id: version_info
         run: |
-          echo "build_version=${{ env.RYUJINX_BASE_VERSION }}.${{ github.run_number }}-canary" >> $GITHUB_OUTPUT
-          echo "prev_build_version=${{ env.RYUJINX_BASE_VERSION }}.$((${{ github.run_number }} - 1))-canary" >> $GITHUB_OUTPUT
+          echo "build_version=${{ env.RYUJINX_BASE_VERSION }}.${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "prev_build_version=${{ env.RYUJINX_BASE_VERSION }}.$((${{ github.run_number }} - 1))" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Create tag

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Get version info
         id: version_info
         run: |
-          echo "build_version=${{ env.RYUJINX_BASE_VERSION }}.${{ github.run_number }}" >> $GITHUB_OUTPUT
-          echo "prev_build_version=${{ env.RYUJINX_BASE_VERSION }}.$((${{ github.run_number }} - 1))" >> $GITHUB_OUTPUT
+          echo "build_version=${{ env.RYUJINX_BASE_VERSION }}.${{ github.run_number }}-canary" >> $GITHUB_OUTPUT
+          echo "prev_build_version=${{ env.RYUJINX_BASE_VERSION }}.$((${{ github.run_number }} - 1))-canary" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Create tag

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,13 +3,13 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.0.10" />
-    <PackageVersion Include="Avalonia.Svg" Version="11.0.0.18" />
-    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.0.0.18" />
+    <PackageVersion Include="Avalonia" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Markup.Xaml.Loader" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Svg" Version="11.1.0" />
+    <PackageVersion Include="Avalonia.Svg.Skia" Version="11.1.0" />
     <PackageVersion Include="Projektanker.Icons.Avalonia" Version="9.4.0" />
     <PackageVersion Include="Projektanker.Icons.Avalonia.FontAwesome" Version="9.4.0"/>
     <PackageVersion Include="Projektanker.Icons.Avalonia.MaterialDesign" Version="9.4.0"/>
@@ -17,7 +17,7 @@
     <PackageVersion Include="Concentus" Version="2.2.2" />
     <PackageVersion Include="DiscordRichPresence" Version="1.2.1.24" />
     <PackageVersion Include="DynamicData" Version="9.0.4" />
-    <PackageVersion Include="FluentAvaloniaUI" Version="2.0.5" />
+    <PackageVersion Include="FluentAvaloniaUI" Version="2.1.0" />
     <PackageVersion Include="Humanizer" Version="2.14.1" />
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />
@@ -41,14 +41,14 @@
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />
-    <PackageVersion Include="Silk.NET.Vulkan" Version="2.21.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.21.0" />
-    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.21.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.8" />
+    <PackageVersion Include="Silk.NET.Vulkan" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.EXT" Version="2.22.0" />
+    <PackageVersion Include="Silk.NET.Vulkan.Extensions.KHR" Version="2.22.0" />
+    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.Management" Version="9.0.0" />
-    <PackageVersion Include="UnicornEngine.Unicorn" Version="2.0.2-rc1-fb78016" />
+    <PackageVersion Include="UnicornEngine.Unicorn" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="NUnit" Version="4.2.2" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />
@@ -50,6 +50,6 @@
     <PackageVersion Include="SPB" Version="0.0.4-build32" />
     <PackageVersion Include="System.IO.Hashing" Version="9.0.0" />
     <PackageVersion Include="System.Management" Version="9.0.0" />
-    <PackageVersion Include="UnicornEngine.Unicorn" Version="2.1.0" />
+    <PackageVersion Include="UnicornEngine.Unicorn" Version="2.0.2-rc1-fb78016" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
+    <PackageVersion Include="NUnit" Version="3.14.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
     <PackageVersion Include="LibHac" Version="0.19.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" />
-    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.0" />
+    <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.2.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
@@ -33,11 +33,12 @@
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.8.2" />
+    <PackageVersion Include="Open.NAT.Core" Version="2.1.0.5" />
     <PackageVersion Include="Ryujinx.Audio.OpenAL.Dependencies" Version="1.21.0.1" />
     <PackageVersion Include="Ryujinx.Graphics.Nvdec.Dependencies" Version="5.0.3-build14" />
     <PackageVersion Include="Ryujinx.Graphics.Vulkan.Dependencies.MoltenVK" Version="1.2.3" />
     <PackageVersion Include="Ryujinx.SDL2-CS" Version="2.30.0-build32" />
-    <PackageVersion Include="Gommon" Version="2.6.5" />
+    <PackageVersion Include="Gommon" Version="2.6.6" />
     <PackageVersion Include="securifybv.ShellLink" Version="0.1.0" />
     <PackageVersion Include="shaderc.net" Version="0.1.0" />
     <PackageVersion Include="SharpZipLib" Version="1.4.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,8 +27,8 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="4.2.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
-    <PackageVersion Include="NUnit" Version="3.14.0" />
+    <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="MsgPack.Cli" Version="1.0.1" />
     <PackageVersion Include="NetCoreServer" Version="8.0.7" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="4.1.0" />
     <PackageVersion Include="OpenTK.Core" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Graphics" Version="4.8.2" />
     <PackageVersion Include="OpenTK.Audio.OpenAL" Version="4.8.2" />

--- a/src/Ryujinx.Common/Configuration/Multiplayer/MultiplayerMode.cs
+++ b/src/Ryujinx.Common/Configuration/Multiplayer/MultiplayerMode.cs
@@ -3,6 +3,7 @@ namespace Ryujinx.Common.Configuration.Multiplayer
     public enum MultiplayerMode
     {
         Disabled,
+        LdnRyu,
         LdnMitm,
     }
 }

--- a/src/Ryujinx.Common/Memory/StructArrayHelpers.cs
+++ b/src/Ryujinx.Common/Memory/StructArrayHelpers.cs
@@ -803,18 +803,6 @@ namespace Ryujinx.Common.Memory
         public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, Length);
     }
 
-    public struct Array256<T> : IArray<T> where T : unmanaged
-    {
-        T _e0;
-        Array128<T> _other;
-        Array127<T> _other2;
-        public readonly int Length => 256;
-        public ref T this[int index] => ref AsSpan()[index];
-
-        [Pure]
-        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, Length);
-    }
-
     public struct Array140<T> : IArray<T> where T : unmanaged
     {
         T _e0;
@@ -822,6 +810,18 @@ namespace Ryujinx.Common.Memory
         Array64<T> _other2;
         Array11<T> _other3;
         public readonly int Length => 140;
+        public ref T this[int index] => ref AsSpan()[index];
+
+        [Pure]
+        public Span<T> AsSpan() => MemoryMarshal.CreateSpan(ref _e0, Length);
+    }
+
+    public struct Array256<T> : IArray<T> where T : unmanaged
+    {
+        T _e0;
+        Array128<T> _other;
+        Array127<T> _other2;
+        public readonly int Length => 256;
         public ref T this[int index] => ref AsSpan()[index];
 
         [Pure]

--- a/src/Ryujinx.Common/Utilities/NetworkHelpers.cs
+++ b/src/Ryujinx.Common/Utilities/NetworkHelpers.cs
@@ -1,6 +1,7 @@
 using System.Buffers.Binary;
 using System.Net;
 using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
 
 namespace Ryujinx.Common.Utilities
 {
@@ -63,6 +64,11 @@ namespace Ryujinx.Common.Utilities
             }
 
             return (targetProperties, targetAddressInfo);
+        }
+        
+        public static bool SupportsDynamicDns()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
         }
 
         public static uint ConvertIpv4Address(IPAddress ipAddress)

--- a/src/Ryujinx.Graphics.Vulkan/Vendor.cs
+++ b/src/Ryujinx.Graphics.Vulkan/Vendor.cs
@@ -92,7 +92,7 @@ namespace Ryujinx.Graphics.Vulkan
                 DriverId.MesaDozen => "Dozen",
                 DriverId.MesaNvk => "NVK",
                 DriverId.ImaginationOpenSourceMesa => "Imagination (Open)",
-                DriverId.MesaAgxv => "Honeykrisp",
+                DriverId.MesaHoneykrisp => "Honeykrisp",
                 _ => id.ToString(),
             };
         }

--- a/src/Ryujinx.HLE/HLEConfiguration.cs
+++ b/src/Ryujinx.HLE/HLEConfiguration.cs
@@ -163,6 +163,21 @@ namespace Ryujinx.HLE
         /// Multiplayer Mode
         /// </summary>
         public MultiplayerMode MultiplayerMode { internal get; set; }
+        
+        /// <summary>
+        /// Disable P2P mode
+        /// </summary>
+        public bool MultiplayerDisableP2p { internal get; set; }
+        
+        /// <summary>
+        /// Multiplayer Passphrase
+        /// </summary>
+        public string MultiplayerLdnPassphrase { internal get; set; }
+        
+        /// <summary>
+        /// LDN Server
+        /// </summary>
+        public string MultiplayerLdnServer { internal get; set; }
 
         /// <summary>
         /// An action called when HLE force a refresh of output after docked mode changed.
@@ -194,7 +209,10 @@ namespace Ryujinx.HLE
                                 float audioVolume,
                                 bool useHypervisor,
                                 string multiplayerLanInterfaceId,
-                                MultiplayerMode multiplayerMode)
+                                MultiplayerMode multiplayerMode,
+                                bool multiplayerDisableP2p,
+                                string multiplayerLdnPassphrase,
+                                string multiplayerLdnServer)
         {
             VirtualFileSystem = virtualFileSystem;
             LibHacHorizonManager = libHacHorizonManager;
@@ -222,6 +240,9 @@ namespace Ryujinx.HLE
             UseHypervisor = useHypervisor;
             MultiplayerLanInterfaceId = multiplayerLanInterfaceId;
             MultiplayerMode = multiplayerMode;
+            MultiplayerDisableP2p = multiplayerDisableP2p;
+            MultiplayerLdnPassphrase = multiplayerLdnPassphrase;
+            MultiplayerLdnServer = multiplayerLdnServer;
         }
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Types/NetworkConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Types/NetworkConfig.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x20)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x20, Pack = 8)]
     struct NetworkConfig
     {
         public IntentId IntentId;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Types/ScanFilter.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Types/ScanFilter.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x60)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x60, Pack = 8)]
     struct ScanFilter
     {
         public NetworkId NetworkId;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Types/SecurityConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Types/SecurityConfig.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x44)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x44, Pack = 2)]
     struct SecurityConfig
     {
         public SecurityMode SecurityMode;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Types/SecurityParameter.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Types/SecurityParameter.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x20)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x20, Pack = 1)]
     struct SecurityParameter
     {
         public Array16<byte> Data;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/Types/UserConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/Types/UserConfig.cs
@@ -3,7 +3,7 @@ using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.Types
 {
-    [StructLayout(LayoutKind.Sequential, Size = 0x30)]
+    [StructLayout(LayoutKind.Sequential, Size = 0x30, Pack = 1)]
     struct UserConfig
     {
         public Array33<byte> UserName;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/AccessPoint.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/AccessPoint.cs
@@ -15,6 +15,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
         public Array8<NodeLatestUpdate> LatestUpdates = new();
         public bool Connected { get; private set; }
 
+        public ProxyConfig Config => _parent.NetworkClient.Config;
+        
         public AccessPoint(IUserLocalCommunicationService parent)
         {
             _parent = parent;
@@ -24,9 +26,12 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public void Dispose()
         {
-            _parent.NetworkClient.DisconnectNetwork();
+            if (_parent?.NetworkClient != null)
+            {
+                _parent.NetworkClient.DisconnectNetwork();
 
-            _parent.NetworkClient.NetworkChange -= NetworkChanged;
+                _parent.NetworkClient.NetworkChange -= NetworkChanged;
+            }
         }
 
         private void NetworkChanged(object sender, NetworkChangeEventArgs e)

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/INetworkClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/INetworkClient.cs
@@ -6,6 +6,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 {
     interface INetworkClient : IDisposable
     {
+        ProxyConfig Config { get; }
         bool NeedsRealId { get; }
 
         event EventHandler<NetworkChangeEventArgs> NetworkChange;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnDisabledClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnDisabledClient.cs
@@ -1,3 +1,4 @@
+using Ryujinx.Common.Logging;
 using Ryujinx.HLE.HOS.Services.Ldn.Types;
 using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
 using System;
@@ -6,12 +7,15 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 {
     class LdnDisabledClient : INetworkClient
     {
+        public ProxyConfig Config { get; }
         public bool NeedsRealId => true;
 
         public event EventHandler<NetworkChangeEventArgs> NetworkChange;
 
         public NetworkError Connect(ConnectRequest request)
         {
+            Logger.Warning?.PrintMsg(LogClass.ServiceLdn,
+                "Attempted to connect to a network, but Multiplayer is disabled!");
             NetworkChange?.Invoke(this, new NetworkChangeEventArgs(new NetworkInfo(), false));
 
             return NetworkError.None;
@@ -19,6 +23,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public NetworkError ConnectPrivate(ConnectPrivateRequest request)
         {
+            Logger.Warning?.PrintMsg(LogClass.ServiceLdn,
+                "Attempted to connect to a network, but Multiplayer is disabled!");
             NetworkChange?.Invoke(this, new NetworkChangeEventArgs(new NetworkInfo(), false));
 
             return NetworkError.None;
@@ -26,6 +32,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public bool CreateNetwork(CreateAccessPointRequest request, byte[] advertiseData)
         {
+            Logger.Warning?.PrintMsg(LogClass.ServiceLdn,
+                "Attempted to create a network, but Multiplayer is disabled!");
             NetworkChange?.Invoke(this, new NetworkChangeEventArgs(new NetworkInfo(), false));
 
             return true;
@@ -33,6 +41,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public bool CreateNetworkPrivate(CreateAccessPointPrivateRequest request, byte[] advertiseData)
         {
+            Logger.Warning?.PrintMsg(LogClass.ServiceLdn,
+                "Attempted to create a network, but Multiplayer is disabled!");
             NetworkChange?.Invoke(this, new NetworkChangeEventArgs(new NetworkInfo(), false));
 
             return true;
@@ -49,6 +59,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public NetworkInfo[] Scan(ushort channel, ScanFilter scanFilter)
         {
+            Logger.Warning?.PrintMsg(LogClass.ServiceLdn,
+                "Attempted to scan for networks, but Multiplayer is disabled!");
             return Array.Empty<NetworkInfo>();
         }
 

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnMitm/LdnMitmClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnMitm/LdnMitmClient.cs
@@ -12,6 +12,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnMitm
     /// </summary>
     internal class LdnMitmClient : INetworkClient
     {
+        public ProxyConfig Config { get; }
         public bool NeedsRealId => false;
 
         public event EventHandler<NetworkChangeEventArgs> NetworkChange;

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/IProxyClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/IProxyClient.cs
@@ -1,0 +1,7 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu
+{
+    interface IProxyClient
+    {
+        bool SendAsync(byte[] buffer);
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/LdnMasterProxyClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/LdnMasterProxyClient.cs
@@ -1,0 +1,642 @@
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.Common.Utilities;
+using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy;
+using Ryujinx.HLE.Utilities;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using TcpClient = NetCoreServer.TcpClient;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu
+{
+    class LdnMasterProxyClient : TcpClient, INetworkClient, IProxyClient
+    {
+        public bool NeedsRealId => true;
+
+        private static InitializeMessage InitializeMemory = new InitializeMessage();
+
+        private const int InactiveTimeout = 6000;
+        private const int FailureTimeout = 4000;
+        private const int ScanTimeout = 1000;
+
+        private bool _useP2pProxy;
+        private NetworkError _lastError;
+
+        private readonly ManualResetEvent _connected = new ManualResetEvent(false);
+        private readonly ManualResetEvent _error = new ManualResetEvent(false);
+        private readonly ManualResetEvent _scan = new ManualResetEvent(false);
+        private readonly ManualResetEvent _reject = new ManualResetEvent(false);
+        private readonly AutoResetEvent _apConnected = new AutoResetEvent(false);
+
+        private readonly RyuLdnProtocol _protocol;
+        private readonly NetworkTimeout _timeout;
+
+        private readonly List<NetworkInfo> _availableGames = new List<NetworkInfo>();
+        private DisconnectReason _disconnectReason;
+
+        private P2pProxyServer _hostedProxy;
+        private P2pProxyClient _connectedProxy;
+
+        private bool _networkConnected;
+
+        private string _passphrase;
+        private byte[] _gameVersion = new byte[0x10];
+
+        private readonly HLEConfiguration _config;
+
+        public event EventHandler<NetworkChangeEventArgs> NetworkChange;
+
+        public ProxyConfig Config { get; private set; }
+
+        public LdnMasterProxyClient(string address, int port, HLEConfiguration config) : base(address, port)
+        {
+            if (ProxyHelpers.SupportsNoDelay())
+            {
+                OptionNoDelay = true;
+            }
+
+            _protocol = new RyuLdnProtocol();
+            _timeout = new NetworkTimeout(InactiveTimeout, TimeoutConnection);
+
+            _protocol.Initialize += HandleInitialize;
+            _protocol.Connected += HandleConnected;
+            _protocol.Reject += HandleReject;
+            _protocol.RejectReply += HandleRejectReply;
+            _protocol.SyncNetwork += HandleSyncNetwork;
+            _protocol.ProxyConfig += HandleProxyConfig;
+            _protocol.Disconnected += HandleDisconnected;
+
+            _protocol.ScanReply += HandleScanReply;
+            _protocol.ScanReplyEnd += HandleScanReplyEnd;
+            _protocol.ExternalProxy += HandleExternalProxy;
+
+            _protocol.Ping += HandlePing;
+            _protocol.NetworkError += HandleNetworkError;
+
+            _config = config;
+            _useP2pProxy = !config.MultiplayerDisableP2p;
+        }
+
+        private void TimeoutConnection()
+        {
+            _connected.Reset();
+
+            DisconnectAsync();
+
+            while (IsConnected)
+            {
+                Thread.Yield();
+            }
+        }
+
+        private bool EnsureConnected()
+        {
+            if (IsConnected)
+            {
+                return true;
+            }
+
+            _error.Reset();
+
+            ConnectAsync();
+
+            int index = WaitHandle.WaitAny(new WaitHandle[] { _connected, _error }, FailureTimeout);
+
+            if (IsConnected)
+            {
+                SendAsync(_protocol.Encode(PacketId.Initialize, InitializeMemory));
+            }
+
+            return index == 0 && IsConnected;
+        }
+
+        private void UpdatePassphraseIfNeeded()
+        {
+            string passphrase = _config.MultiplayerLdnPassphrase ?? "";
+            if (passphrase != _passphrase)
+            {
+                _passphrase = passphrase;
+
+                SendAsync(_protocol.Encode(PacketId.Passphrase,
+                    StringUtils.GetFixedLengthBytes(passphrase, 0x80, Encoding.UTF8)));
+            }
+        }
+
+        protected override void OnConnected()
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"LDN TCP client connected a new session with Id {Id}");
+
+            UpdatePassphraseIfNeeded();
+
+            _connected.Set();
+        }
+
+        protected override void OnDisconnected()
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"LDN TCP client disconnected a session with Id {Id}");
+
+            _passphrase = null;
+
+            _connected.Reset();
+
+            if (_networkConnected)
+            {
+                DisconnectInternal();
+            }
+        }
+
+        public void DisconnectAndStop()
+        {
+            _timeout.Dispose();
+
+            DisconnectAsync();
+
+            while (IsConnected)
+            {
+                Thread.Yield();
+            }
+
+            Dispose();
+        }
+
+        protected override void OnReceived(byte[] buffer, long offset, long size)
+        {
+            _protocol.Read(buffer, (int)offset, (int)size);
+        }
+
+        protected override void OnError(SocketError error)
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"LDN TCP client caught an error with code {error}");
+
+            _error.Set();
+        }
+
+
+        private void HandleInitialize(LdnHeader header, InitializeMessage initialize)
+        {
+            InitializeMemory = initialize;
+        }
+
+        private void HandleExternalProxy(LdnHeader header, ExternalProxyConfig config)
+        {
+            int length = config.AddressFamily switch
+            {
+                AddressFamily.InterNetwork => 4,
+                AddressFamily.InterNetworkV6 => 16,
+                _ => 0
+            };
+
+            if (length == 0)
+            {
+                return; // Invalid external proxy.
+            }
+
+            IPAddress address = new(config.ProxyIp.AsSpan()[..length].ToArray());
+            P2pProxyClient proxy = new(address.ToString(), config.ProxyPort);
+
+            _connectedProxy = proxy;
+
+            bool success = proxy.PerformAuth(config);
+
+            if (!success)
+            {
+                DisconnectInternal();
+            }
+        }
+
+        private void HandlePing(LdnHeader header, PingMessage ping)
+        {
+            if (ping.Requester == 0) // Server requested.
+            {
+                // Send the ping message back.
+
+                SendAsync(_protocol.Encode(PacketId.Ping, ping));
+            }
+        }
+
+        private void HandleNetworkError(LdnHeader header, NetworkErrorMessage error)
+        {
+            if (error.Error == NetworkError.PortUnreachable)
+            {
+                _useP2pProxy = false;
+            }
+            else
+            {
+                _lastError = error.Error;
+            }
+        }
+
+        private NetworkError ConsumeNetworkError()
+        {
+            NetworkError result = _lastError;
+
+            _lastError = NetworkError.None;
+
+            return result;
+        }
+
+        private void HandleSyncNetwork(LdnHeader header, NetworkInfo info)
+        {
+            NetworkChange?.Invoke(this, new NetworkChangeEventArgs(info, true));
+        }
+
+        private void HandleConnected(LdnHeader header, NetworkInfo info)
+        {
+            _networkConnected = true;
+            _disconnectReason = DisconnectReason.None;
+
+            _apConnected.Set();
+
+            NetworkChange?.Invoke(this, new NetworkChangeEventArgs(info, true));
+        }
+
+        private void HandleDisconnected(LdnHeader header, DisconnectMessage message)
+        {
+            DisconnectInternal();
+        }
+
+        private void HandleReject(LdnHeader header, RejectRequest reject)
+        {
+            // When the client receives a Reject request, we have been rejected and will be disconnected shortly.
+            _disconnectReason = reject.DisconnectReason;
+        }
+
+        private void HandleRejectReply(LdnHeader header)
+        {
+            _reject.Set();
+        }
+
+        private void HandleScanReply(LdnHeader header, NetworkInfo info)
+        {
+            _availableGames.Add(info);
+        }
+
+        private void HandleScanReplyEnd(LdnHeader obj)
+        {
+            _scan.Set();
+        }
+
+        private void DisconnectInternal()
+        {
+            if (_networkConnected)
+            {
+                _networkConnected = false;
+
+                _hostedProxy?.Dispose();
+                _hostedProxy = null;
+
+                _connectedProxy?.Dispose();
+                _connectedProxy = null;
+
+                _apConnected.Reset();
+
+                NetworkChange?.Invoke(this, new NetworkChangeEventArgs(new NetworkInfo(), false, _disconnectReason));
+
+                if (IsConnected)
+                {
+                    _timeout.RefreshTimeout();
+                }
+            }
+        }
+
+        public void DisconnectNetwork()
+        {
+            if (_networkConnected)
+            {
+                SendAsync(_protocol.Encode(PacketId.Disconnect, new DisconnectMessage()));
+
+                DisconnectInternal();
+            }
+        }
+
+        public ResultCode Reject(DisconnectReason disconnectReason, uint nodeId)
+        {
+            if (_networkConnected)
+            {
+                _reject.Reset();
+
+                SendAsync(_protocol.Encode(PacketId.Reject, new RejectRequest(disconnectReason, nodeId)));
+
+                int index = WaitHandle.WaitAny(new WaitHandle[] { _reject, _error }, InactiveTimeout);
+
+                if (index == 0)
+                {
+                    return (ConsumeNetworkError() != NetworkError.None) ? ResultCode.InvalidState : ResultCode.Success;
+                }
+            }
+
+            return ResultCode.InvalidState;
+        }
+
+        public void SetAdvertiseData(byte[] data)
+        {
+            // TODO: validate we're the owner (the server will do this anyways tho)
+            if (_networkConnected)
+            {
+                SendAsync(_protocol.Encode(PacketId.SetAdvertiseData, data));
+            }
+        }
+
+        public void SetGameVersion(byte[] versionString)
+        {
+            _gameVersion = versionString;
+
+            if (_gameVersion.Length < 0x10)
+            {
+                Array.Resize(ref _gameVersion, 0x10);
+            }
+        }
+
+        public void SetStationAcceptPolicy(AcceptPolicy acceptPolicy)
+        {
+            // TODO: validate we're the owner (the server will do this anyways tho)
+            if (_networkConnected)
+            {
+                SendAsync(_protocol.Encode(PacketId.SetAcceptPolicy,
+                    new SetAcceptPolicyRequest { StationAcceptPolicy = acceptPolicy }));
+            }
+        }
+
+        private void DisposeProxy()
+        {
+            _hostedProxy?.Dispose();
+            _hostedProxy = null;
+        }
+
+        private void ConfigureAccessPoint(ref RyuNetworkConfig request)
+        {
+            _gameVersion.AsSpan().CopyTo(request.GameVersion.AsSpan());
+
+            if (_useP2pProxy)
+            {
+                // Before sending the request, attempt to set up a proxy server.
+                // This can be on a range of private ports, which can be exposed on a range of public
+                // ports via UPnP. If any of this fails, we just fall back to using the master server.
+
+                int i = 0;
+                for (; i < P2pProxyServer.PrivatePortRange; i++)
+                {
+                    _hostedProxy = new P2pProxyServer(this, (ushort)(P2pProxyServer.PrivatePortBase + i), _protocol);
+
+                    try
+                    {
+                        _hostedProxy.Start();
+
+                        break;
+                    }
+                    catch (SocketException e)
+                    {
+                        _hostedProxy.Dispose();
+                        _hostedProxy = null;
+
+                        if (e.SocketErrorCode != SocketError.AddressAlreadyInUse)
+                        {
+                            i = P2pProxyServer.PrivatePortRange; // Immediately fail.
+                        }
+                    }
+                }
+
+                bool openSuccess = i < P2pProxyServer.PrivatePortRange;
+
+                if (openSuccess)
+                {
+                    Task<ushort> natPunchResult = _hostedProxy.NatPunch();
+
+                    try
+                    {
+                        if (natPunchResult.Result != 0)
+                        {
+                            // Tell the server that we are hosting the proxy.
+                            request.ExternalProxyPort = natPunchResult.Result;
+                        }
+                    }
+                    catch (Exception) { }
+
+                    if (request.ExternalProxyPort == 0)
+                    {
+                        Logger.Warning?.Print(LogClass.ServiceLdn,
+                            "Failed to open a port with UPnP for P2P connection. Proxying through the master server instead. Expect higher latency.");
+                        _hostedProxy.Dispose();
+                    }
+                    else
+                    {
+                        Logger.Info?.Print(LogClass.ServiceLdn,
+                            $"Created a wireless P2P network on port {request.ExternalProxyPort}.");
+                        _hostedProxy.Start();
+
+                        (_, UnicastIPAddressInformation unicastAddress) = NetworkHelpers.GetLocalInterface();
+
+                        unicastAddress.Address.GetAddressBytes().AsSpan().CopyTo(request.PrivateIp.AsSpan());
+                        request.InternalProxyPort = _hostedProxy.PrivatePort;
+                        request.AddressFamily = unicastAddress.Address.AddressFamily;
+                    }
+                }
+                else
+                {
+                    Logger.Warning?.Print(LogClass.ServiceLdn,
+                        "Cannot create a P2P server. Proxying through the master server instead. Expect higher latency.");
+                }
+            }
+        }
+
+        private bool CreateNetworkCommon()
+        {
+            bool signalled = _apConnected.WaitOne(FailureTimeout);
+
+            if (!_useP2pProxy && _hostedProxy != null)
+            {
+                Logger.Warning?.Print(LogClass.ServiceLdn,
+                    "Locally hosted proxy server was not externally reachable. Proxying through the master server instead. Expect higher latency.");
+
+                DisposeProxy();
+            }
+
+            if (signalled && _connectedProxy != null)
+            {
+                _connectedProxy.EnsureProxyReady();
+
+                Config = _connectedProxy.ProxyConfig;
+            }
+            else
+            {
+                DisposeProxy();
+            }
+
+            return signalled;
+        }
+
+        public bool CreateNetwork(CreateAccessPointRequest request, byte[] advertiseData)
+        {
+            _timeout.DisableTimeout();
+
+            ConfigureAccessPoint(ref request.RyuNetworkConfig);
+
+            if (!EnsureConnected())
+            {
+                DisposeProxy();
+
+                return false;
+            }
+
+            UpdatePassphraseIfNeeded();
+
+            SendAsync(_protocol.Encode(PacketId.CreateAccessPoint, request, advertiseData));
+
+            // Send a network change event with dummy data immediately. Necessary to avoid crashes in some games
+            var networkChangeEvent = new NetworkChangeEventArgs(
+                new NetworkInfo()
+                {
+                    Common = new CommonNetworkInfo()
+                    {
+                        MacAddress = InitializeMemory.MacAddress,
+                        Channel = request.NetworkConfig.Channel,
+                        LinkLevel = 3,
+                        NetworkType = 2,
+                        Ssid = new Ssid() { Length = 32 }
+                    },
+                    Ldn = new LdnNetworkInfo()
+                    {
+                        AdvertiseDataSize = (ushort)advertiseData.Length,
+                        AuthenticationId = 0,
+                        NodeCount = 1,
+                        NodeCountMax = request.NetworkConfig.NodeCountMax,
+                        SecurityMode = (ushort)request.SecurityConfig.SecurityMode
+                    }
+                }, true);
+            networkChangeEvent.Info.Ldn.Nodes[0] = new NodeInfo()
+            {
+                Ipv4Address = 175243265,
+                IsConnected = 1,
+                LocalCommunicationVersion = request.NetworkConfig.LocalCommunicationVersion,
+                MacAddress = InitializeMemory.MacAddress,
+                NodeId = 0,
+                UserName = request.UserConfig.UserName
+            };
+            "12345678123456781234567812345678"u8.ToArray().CopyTo(networkChangeEvent.Info.Common.Ssid.Name.AsSpan());
+            NetworkChange?.Invoke(this, networkChangeEvent);
+
+            return CreateNetworkCommon();
+        }
+
+        public bool CreateNetworkPrivate(CreateAccessPointPrivateRequest request, byte[] advertiseData)
+        {
+            _timeout.DisableTimeout();
+
+            ConfigureAccessPoint(ref request.RyuNetworkConfig);
+
+            if (!EnsureConnected())
+            {
+                DisposeProxy();
+
+                return false;
+            }
+
+            UpdatePassphraseIfNeeded();
+
+            SendAsync(_protocol.Encode(PacketId.CreateAccessPointPrivate, request, advertiseData));
+
+            return CreateNetworkCommon();
+        }
+
+        public NetworkInfo[] Scan(ushort channel, ScanFilter scanFilter)
+        {
+            if (!_networkConnected)
+            {
+                _timeout.RefreshTimeout();
+            }
+
+            _availableGames.Clear();
+
+            int index = -1;
+
+            if (EnsureConnected())
+            {
+                UpdatePassphraseIfNeeded();
+
+                _scan.Reset();
+
+                SendAsync(_protocol.Encode(PacketId.Scan, scanFilter));
+
+                index = WaitHandle.WaitAny(new WaitHandle[] { _scan, _error }, ScanTimeout);
+            }
+
+            if (index != 0)
+            {
+                // An error occurred or timeout. Write 0 games.
+                return Array.Empty<NetworkInfo>();
+            }
+
+            return _availableGames.ToArray();
+        }
+
+        private NetworkError ConnectCommon()
+        {
+            bool signalled = _apConnected.WaitOne(FailureTimeout);
+
+            NetworkError error = ConsumeNetworkError();
+
+            if (error != NetworkError.None)
+            {
+                return error;
+            }
+
+            if (signalled && _connectedProxy != null)
+            {
+                _connectedProxy.EnsureProxyReady();
+
+                Config = _connectedProxy.ProxyConfig;
+            }
+
+            return signalled ? NetworkError.None : NetworkError.ConnectTimeout;
+        }
+
+        public NetworkError Connect(ConnectRequest request)
+        {
+            _timeout.DisableTimeout();
+
+            if (!EnsureConnected())
+            {
+                return NetworkError.Unknown;
+            }
+
+            SendAsync(_protocol.Encode(PacketId.Connect, request));
+
+            var networkChangeEvent = new NetworkChangeEventArgs(
+                new NetworkInfo() { Common = request.NetworkInfo.Common, Ldn = request.NetworkInfo.Ldn }, true);
+
+            NetworkChange?.Invoke(this, networkChangeEvent);
+
+            return ConnectCommon();
+        }
+
+        public NetworkError ConnectPrivate(ConnectPrivateRequest request)
+        {
+            _timeout.DisableTimeout();
+
+            if (!EnsureConnected())
+            {
+                return NetworkError.Unknown;
+            }
+
+            SendAsync(_protocol.Encode(PacketId.ConnectPrivate, request));
+
+            return ConnectCommon();
+        }
+
+        private void HandleProxyConfig(LdnHeader header, ProxyConfig config)
+        {
+            Config = config;
+
+            SocketHelpers.RegisterProxy(new LdnProxy(config, this, _protocol));
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/NetworkTimeout.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/NetworkTimeout.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu
+{
+    class NetworkTimeout : IDisposable
+    {
+        private readonly int _idleTimeout;
+        private readonly Action _timeoutCallback;
+        private CancellationTokenSource _cancel;
+        private readonly object _lock = new object();
+
+        public NetworkTimeout(int idleTimeout, Action timeoutCallback)
+        {
+            _idleTimeout = idleTimeout;
+            _timeoutCallback = timeoutCallback;
+        }
+
+        private async Task TimeoutTask()
+        {
+            CancellationTokenSource cts;
+            lock (_lock)
+            {
+                cts = _cancel;
+            }
+
+            if (cts == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await Task.Delay(_idleTimeout, cts.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                return; // Timeout cancelled.
+            }
+
+            lock (_lock)
+            {
+                // Run the timeout callback. If the cancel token source has been replaced, we have _just_ been cancelled.
+                if (cts == _cancel)
+                {
+                    _timeoutCallback();
+                }
+            }
+        }
+
+        public bool RefreshTimeout()
+        {
+            lock (_lock)
+            {
+                _cancel?.Cancel();
+                _cancel = new CancellationTokenSource();
+                Task.Run(TimeoutTask);
+            }
+
+            return true;
+        }
+
+        public void DisableTimeout()
+        {
+            lock (_lock)
+            {
+                _cancel?.Cancel();
+                _cancel = new CancellationTokenSource();
+            }
+        }
+
+        public void Dispose()
+        {
+            DisableTimeout();
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/EphemeralPortPool.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/EphemeralPortPool.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    public class EphemeralPortPool
+    {
+        private const ushort EphemeralBase = 49152;
+        private readonly List<ushort> _ephemeralPorts = new List<ushort>();
+        private readonly object _lock = new object();
+
+        public ushort Get()
+        {
+            ushort port = EphemeralBase;
+            lock (_lock)
+            {
+                // Starting at the ephemeral port base, return an ephemeral port that is not in use.
+                // Returns 0 if the range is exhausted.
+                for (int i = 0; i < _ephemeralPorts.Count; i++)
+                {
+                    ushort existingPort = _ephemeralPorts[i];
+                    if (existingPort > port)
+                    {
+                        // The port was free - take it.
+                        _ephemeralPorts.Insert(i, port);
+                        return port;
+                    }
+
+                    port++;
+                }
+
+                if (port != 0)
+                {
+                    _ephemeralPorts.Add(port);
+                }
+
+                return port;
+            }
+        }
+
+        public void Return(ushort port)
+        {
+            lock (_lock)
+            {
+                _ephemeralPorts.Remove(port);
+            }
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/LdnProxy.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/LdnProxy.cs
@@ -1,0 +1,232 @@
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    class LdnProxy : IDisposable
+    {
+        public EndPoint LocalEndpoint { get; }
+        public IPAddress LocalAddress { get; }
+        private readonly List<LdnProxySocket> _sockets = new List<LdnProxySocket>();
+
+        private readonly Dictionary<ProtocolType, EphemeralPortPool> _ephemeralPorts =
+            new Dictionary<ProtocolType, EphemeralPortPool>();
+
+        private readonly IProxyClient _parent;
+        private RyuLdnProtocol _protocol;
+        private readonly uint _subnetMask;
+        private readonly uint _localIp;
+        private readonly uint _broadcast;
+
+        public LdnProxy(ProxyConfig config, IProxyClient client, RyuLdnProtocol protocol)
+        {
+            _parent = client;
+            _protocol = protocol;
+            _ephemeralPorts[ProtocolType.Udp] = new EphemeralPortPool();
+            _ephemeralPorts[ProtocolType.Tcp] = new EphemeralPortPool();
+            byte[] address = BitConverter.GetBytes(config.ProxyIp);
+            Array.Reverse(address);
+            LocalAddress = new IPAddress(address);
+            _subnetMask = config.ProxySubnetMask;
+            _localIp = config.ProxyIp;
+            _broadcast = _localIp | (~_subnetMask);
+            RegisterHandlers(protocol);
+        }
+
+        public bool Supported(AddressFamily domain, SocketType type, ProtocolType protocol)
+        {
+            if (protocol == ProtocolType.Tcp)
+            {
+                Logger.Error?.PrintMsg(LogClass.ServiceLdn,
+                    "Tcp proxy networking is untested. Please report this game so that it can be tested.");
+            }
+
+            return domain == AddressFamily.InterNetwork &&
+                   (protocol == ProtocolType.Tcp || protocol == ProtocolType.Udp);
+        }
+
+        private void RegisterHandlers(RyuLdnProtocol protocol)
+        {
+            protocol.ProxyConnect += HandleConnectionRequest;
+            protocol.ProxyConnectReply += HandleConnectionResponse;
+            protocol.ProxyData += HandleData;
+            protocol.ProxyDisconnect += HandleDisconnect;
+            _protocol = protocol;
+        }
+
+        public void UnregisterHandlers(RyuLdnProtocol protocol)
+        {
+            protocol.ProxyConnect -= HandleConnectionRequest;
+            protocol.ProxyConnectReply -= HandleConnectionResponse;
+            protocol.ProxyData -= HandleData;
+            protocol.ProxyDisconnect -= HandleDisconnect;
+        }
+
+        public ushort GetEphemeralPort(ProtocolType type)
+        {
+            return _ephemeralPorts[type].Get();
+        }
+
+        public void ReturnEphemeralPort(ProtocolType type, ushort port)
+        {
+            _ephemeralPorts[type].Return(port);
+        }
+
+        public void RegisterSocket(LdnProxySocket socket)
+        {
+            lock (_sockets)
+            {
+                _sockets.Add(socket);
+            }
+        }
+
+        public void UnregisterSocket(LdnProxySocket socket)
+        {
+            lock (_sockets)
+            {
+                _sockets.Remove(socket);
+            }
+        }
+
+        private void ForRoutedSockets(ProxyInfo info, Action<LdnProxySocket> action)
+        {
+            lock (_sockets)
+            {
+                foreach (LdnProxySocket socket in _sockets)
+                {
+                    // Must match protocol and destination port.
+                    if (socket.ProtocolType != info.Protocol || socket.LocalEndPoint is not IPEndPoint endpoint ||
+                        endpoint.Port != info.DestPort)
+                    {
+                        continue;
+                    }
+
+                    // We can assume packets routed to us have been sent to our destination.
+                    // They will either be sent to us, or broadcast packets.
+                    action(socket);
+                }
+            }
+        }
+
+        public void HandleConnectionRequest(LdnHeader header, ProxyConnectRequest request)
+        {
+            ForRoutedSockets(request.Info, (socket) =>
+            {
+                socket.HandleConnectRequest(request);
+            });
+        }
+
+        public void HandleConnectionResponse(LdnHeader header, ProxyConnectResponse response)
+        {
+            ForRoutedSockets(response.Info, (socket) =>
+            {
+                socket.HandleConnectResponse(response);
+            });
+        }
+
+        public void HandleData(LdnHeader header, ProxyDataHeader proxyHeader, byte[] data)
+        {
+            ProxyDataPacket packet = new ProxyDataPacket() { Header = proxyHeader, Data = data };
+            ForRoutedSockets(proxyHeader.Info, (socket) =>
+            {
+                socket.IncomingData(packet);
+            });
+        }
+
+        public void HandleDisconnect(LdnHeader header, ProxyDisconnectMessage disconnect)
+        {
+            ForRoutedSockets(disconnect.Info, (socket) =>
+            {
+                socket.HandleDisconnect(disconnect);
+            });
+        }
+
+        private uint GetIpV4(IPEndPoint endpoint)
+        {
+            if (endpoint.AddressFamily != AddressFamily.InterNetwork)
+            {
+                throw new NotSupportedException();
+            }
+
+            byte[] address = endpoint.Address.GetAddressBytes();
+            Array.Reverse(address);
+            return BitConverter.ToUInt32(address);
+        }
+
+        private ProxyInfo MakeInfo(IPEndPoint localEp, IPEndPoint remoteEP, ProtocolType type)
+        {
+            return new ProxyInfo
+            {
+                SourceIpV4 = GetIpV4(localEp),
+                SourcePort = (ushort)localEp.Port,
+                DestIpV4 = GetIpV4(remoteEP),
+                DestPort = (ushort)remoteEP.Port,
+                Protocol = type
+            };
+        }
+
+        public void RequestConnection(IPEndPoint localEp, IPEndPoint remoteEp, ProtocolType type)
+        {
+            // We must ask the other side to initialize a connection, so they can accept a socket for us.
+            ProxyConnectRequest request = new ProxyConnectRequest { Info = MakeInfo(localEp, remoteEp, type) };
+            _parent.SendAsync(_protocol.Encode(PacketId.ProxyConnect, request));
+        }
+
+        public void SignalConnected(IPEndPoint localEp, IPEndPoint remoteEp, ProtocolType type)
+        {
+            // We must tell the other side that we have accepted their request for connection.
+            ProxyConnectResponse request = new ProxyConnectResponse { Info = MakeInfo(localEp, remoteEp, type) };
+            _parent.SendAsync(_protocol.Encode(PacketId.ProxyConnectReply, request));
+        }
+
+        public void EndConnection(IPEndPoint localEp, IPEndPoint remoteEp, ProtocolType type)
+        {
+            // We must tell the other side that our connection is dropped.
+            ProxyDisconnectMessage request = new ProxyDisconnectMessage
+            {
+                Info = MakeInfo(localEp, remoteEp, type), DisconnectReason = 0 // TODO
+            };
+            _parent.SendAsync(_protocol.Encode(PacketId.ProxyDisconnect, request));
+        }
+
+        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags flags, IPEndPoint localEp, IPEndPoint remoteEp,
+            ProtocolType type)
+        {
+            // We send exactly as much as the user wants us to, currently instantly.
+            // TODO: handle over "virtual mtu" (we have a max packet size to worry about anyways). fragment if tcp? throw if udp?
+            ProxyDataHeader request = new ProxyDataHeader
+            {
+                Info = MakeInfo(localEp, remoteEp, type), DataLength = (uint)buffer.Length
+            };
+            _parent.SendAsync(_protocol.Encode(PacketId.ProxyData, request, buffer.ToArray()));
+            return buffer.Length;
+        }
+
+        public bool IsBroadcast(uint ip)
+        {
+            return ip == _broadcast;
+        }
+
+        public bool IsMyself(uint ip)
+        {
+            return ip == _localIp;
+        }
+
+        public void Dispose()
+        {
+            UnregisterHandlers(_protocol);
+            lock (_sockets)
+            {
+                foreach (LdnProxySocket socket in _sockets)
+                {
+                    socket.ProxyDestroyed();
+                }
+            }
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/LdnProxySocket.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/LdnProxySocket.cs
@@ -1,0 +1,803 @@
+﻿using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    /// <summary>
+    /// This socket is forwarded through a TCP stream that goes through the Ldn server.
+    /// The Ldn server will then route the packets we send (or need to receive) within the virtual adhoc network.
+    /// </summary>
+    class LdnProxySocket : ISocketImpl
+    {
+        private readonly LdnProxy _proxy;
+
+        private bool _isListening;
+        private readonly List<LdnProxySocket> _listenSockets = new List<LdnProxySocket>();
+
+        private readonly Queue<ProxyConnectRequest> _connectRequests = new Queue<ProxyConnectRequest>();
+
+        private readonly AutoResetEvent _acceptEvent = new AutoResetEvent(false);
+        private readonly int _acceptTimeout = -1;
+
+        private readonly Queue<int> _errors = new Queue<int>();
+
+        private readonly AutoResetEvent _connectEvent = new AutoResetEvent(false);
+        private ProxyConnectResponse _connectResponse;
+
+        private int _receiveTimeout = -1;
+        private readonly AutoResetEvent _receiveEvent = new AutoResetEvent(false);
+        private readonly Queue<ProxyDataPacket> _receiveQueue = new Queue<ProxyDataPacket>();
+
+        // private int _sendTimeout = -1; // Sends are techically instant right now, so not _really_ used.
+
+        private bool _connecting;
+        private bool _broadcast;
+
+        private bool _readShutdown;
+
+        // private bool _writeShutdown;
+        private bool _closed;
+
+        private readonly Dictionary<SocketOptionName, int> _socketOptions = new Dictionary<SocketOptionName, int>()
+        {
+            { SocketOptionName.Broadcast, 0 }, //TODO: honor this value
+            { SocketOptionName.DontLinger, 0 },
+            { SocketOptionName.Debug, 0 },
+            { SocketOptionName.Error, 0 },
+            { SocketOptionName.KeepAlive, 0 },
+            { SocketOptionName.OutOfBandInline, 0 },
+            { SocketOptionName.ReceiveBuffer, 131072 },
+            { SocketOptionName.ReceiveTimeout, -1 },
+            { SocketOptionName.SendBuffer, 131072 },
+            { SocketOptionName.SendTimeout, -1 },
+            { SocketOptionName.Type, 0 },
+            { SocketOptionName.ReuseAddress, 0 } //TODO: honor this value
+        };
+
+        public EndPoint RemoteEndPoint { get; private set; }
+
+        public EndPoint LocalEndPoint { get; private set; }
+
+        public bool Connected { get; private set; }
+
+        public bool IsBound { get; private set; }
+
+        public AddressFamily AddressFamily { get; }
+
+        public SocketType SocketType { get; }
+
+        public ProtocolType ProtocolType { get; }
+
+        public bool Blocking { get; set; }
+
+        public int Available
+        {
+            get
+            {
+                int result = 0;
+
+                lock (_receiveQueue)
+                {
+                    foreach (ProxyDataPacket data in _receiveQueue)
+                    {
+                        result += data.Data.Length;
+                    }
+                }
+
+                return result;
+            }
+        }
+
+        public bool Readable
+        {
+            get
+            {
+                if (_isListening)
+                {
+                    lock (_connectRequests)
+                    {
+                        return _connectRequests.Count > 0;
+                    }
+                }
+                else
+                {
+                    if (_readShutdown)
+                    {
+                        return true;
+                    }
+
+                    lock (_receiveQueue)
+                    {
+                        return _receiveQueue.Count > 0;
+                    }
+                }
+            }
+        }
+
+        public bool Writable => Connected || ProtocolType == ProtocolType.Udp;
+        public bool Error => false;
+
+        public LdnProxySocket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType,
+            LdnProxy proxy)
+        {
+            AddressFamily = addressFamily;
+            SocketType = socketType;
+            ProtocolType = protocolType;
+
+            _proxy = proxy;
+            _socketOptions[SocketOptionName.Type] = (int)socketType;
+
+            proxy.RegisterSocket(this);
+        }
+
+        private IPEndPoint EnsureLocalEndpoint(bool replace)
+        {
+            if (LocalEndPoint != null)
+            {
+                if (replace)
+                {
+                    _proxy.ReturnEphemeralPort(ProtocolType, (ushort)((IPEndPoint)LocalEndPoint).Port);
+                }
+                else
+                {
+                    return (IPEndPoint)LocalEndPoint;
+                }
+            }
+
+            IPEndPoint localEp = new IPEndPoint(_proxy.LocalAddress, _proxy.GetEphemeralPort(ProtocolType));
+            LocalEndPoint = localEp;
+
+            return localEp;
+        }
+
+        public LdnProxySocket AsAccepted(IPEndPoint remoteEp)
+        {
+            Connected = true;
+            RemoteEndPoint = remoteEp;
+
+            IPEndPoint localEp = EnsureLocalEndpoint(true);
+
+            _proxy.SignalConnected(localEp, remoteEp, ProtocolType);
+
+            return this;
+        }
+
+        private void SignalError(WsaError error)
+        {
+            lock (_errors)
+            {
+                _errors.Enqueue((int)error);
+            }
+        }
+
+        private IPEndPoint GetEndpoint(uint ipv4, ushort port)
+        {
+            byte[] address = BitConverter.GetBytes(ipv4);
+            Array.Reverse(address);
+
+            return new IPEndPoint(new IPAddress(address), port);
+        }
+
+        public void IncomingData(ProxyDataPacket packet)
+        {
+            bool isBroadcast = _proxy.IsBroadcast(packet.Header.Info.DestIpV4);
+
+            if (!_closed && (_broadcast || !isBroadcast))
+            {
+                lock (_receiveQueue)
+                {
+                    _receiveQueue.Enqueue(packet);
+                }
+            }
+        }
+
+        public ISocketImpl Accept()
+        {
+            if (!_isListening)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // Accept a pending request to this socket.
+
+            lock (_connectRequests)
+            {
+                if (!Blocking && _connectRequests.Count == 0)
+                {
+                    throw new SocketException((int)WsaError.WSAEWOULDBLOCK);
+                }
+            }
+
+            while (true)
+            {
+                _acceptEvent.WaitOne(_acceptTimeout);
+
+                lock (_connectRequests)
+                {
+                    while (_connectRequests.Count > 0)
+                    {
+                        ProxyConnectRequest request = _connectRequests.Dequeue();
+
+                        if (_connectRequests.Count > 0)
+                        {
+                            _acceptEvent.Set(); // Still more accepts to do.
+                        }
+
+                        // Is this request made for us?
+                        IPEndPoint endpoint = GetEndpoint(request.Info.DestIpV4, request.Info.DestPort);
+
+                        if (Equals(endpoint, LocalEndPoint))
+                        {
+                            // Yes - let's accept.
+                            IPEndPoint remoteEndpoint = GetEndpoint(request.Info.SourceIpV4, request.Info.SourcePort);
+
+                            LdnProxySocket socket =
+                                new LdnProxySocket(AddressFamily, SocketType, ProtocolType, _proxy).AsAccepted(
+                                    remoteEndpoint);
+
+                            lock (_listenSockets)
+                            {
+                                _listenSockets.Add(socket);
+                            }
+
+                            return socket;
+                        }
+                    }
+                }
+            }
+        }
+
+        public void Bind(EndPoint localEP)
+        {
+            ArgumentNullException.ThrowIfNull(localEP);
+
+            if (LocalEndPoint != null)
+            {
+                _proxy.ReturnEphemeralPort(ProtocolType, (ushort)((IPEndPoint)LocalEndPoint).Port);
+            }
+
+            var asIPEndpoint = (IPEndPoint)localEP;
+            if (asIPEndpoint.Port == 0)
+            {
+                asIPEndpoint.Port = (ushort)_proxy.GetEphemeralPort(ProtocolType);
+            }
+
+            LocalEndPoint = (IPEndPoint)localEP;
+
+            IsBound = true;
+        }
+
+        public void Close()
+        {
+            _closed = true;
+
+            _proxy.UnregisterSocket(this);
+
+            if (Connected)
+            {
+                Disconnect(false);
+            }
+
+            lock (_listenSockets)
+            {
+                foreach (LdnProxySocket socket in _listenSockets)
+                {
+                    socket.Close();
+                }
+            }
+
+            _isListening = false;
+        }
+
+        public void Connect(EndPoint remoteEP)
+        {
+            if (_isListening || !IsBound)
+            {
+                throw new InvalidOperationException();
+            }
+
+            if (remoteEP is not IPEndPoint)
+            {
+                throw new NotSupportedException();
+            }
+
+            IPEndPoint localEp = EnsureLocalEndpoint(true);
+
+            _connecting = true;
+
+            _proxy.RequestConnection(localEp, (IPEndPoint)remoteEP, ProtocolType);
+
+            if (!Blocking && ProtocolType == ProtocolType.Tcp)
+            {
+                throw new SocketException((int)WsaError.WSAEWOULDBLOCK);
+            }
+
+            _connectEvent.WaitOne(); //timeout?
+
+            if (_connectResponse.Info.SourceIpV4 == 0)
+            {
+                throw new SocketException((int)WsaError.WSAECONNREFUSED);
+            }
+
+            _connectResponse = default;
+        }
+
+        public void HandleConnectResponse(ProxyConnectResponse obj)
+        {
+            if (!_connecting)
+            {
+                return;
+            }
+
+            _connecting = false;
+
+            if (_connectResponse.Info.SourceIpV4 != 0)
+            {
+                IPEndPoint remoteEp = GetEndpoint(obj.Info.SourceIpV4, obj.Info.SourcePort);
+                RemoteEndPoint = remoteEp;
+
+                Connected = true;
+            }
+            else
+            {
+                // Connection failed
+
+                SignalError(WsaError.WSAECONNREFUSED);
+            }
+        }
+
+        public void Disconnect(bool reuseSocket)
+        {
+            if (Connected)
+            {
+                ConnectionEnded();
+
+                // The other side needs to be notified that connection ended.
+                _proxy.EndConnection(LocalEndPoint as IPEndPoint, RemoteEndPoint as IPEndPoint, ProtocolType);
+            }
+        }
+
+        private void ConnectionEnded()
+        {
+            if (Connected)
+            {
+                RemoteEndPoint = null;
+                Connected = false;
+            }
+        }
+
+        public void GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue)
+        {
+            if (optionLevel != SocketOptionLevel.Socket)
+            {
+                throw new NotImplementedException();
+            }
+
+            if (_socketOptions.TryGetValue(optionName, out int result))
+            {
+                byte[] data = BitConverter.GetBytes(result);
+                Array.Copy(data, 0, optionValue, 0, Math.Min(data.Length, optionValue.Length));
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public void Listen(int backlog)
+        {
+            if (!IsBound)
+            {
+                throw new SocketException();
+            }
+
+            _isListening = true;
+        }
+
+        public void HandleConnectRequest(ProxyConnectRequest obj)
+        {
+            lock (_connectRequests)
+            {
+                _connectRequests.Enqueue(obj);
+            }
+
+            _connectEvent.Set();
+        }
+
+        public void HandleDisconnect(ProxyDisconnectMessage message)
+        {
+            Disconnect(false);
+        }
+
+        public int Receive(Span<byte> buffer)
+        {
+            EndPoint dummy = new IPEndPoint(IPAddress.Any, 0);
+
+            return ReceiveFrom(buffer, SocketFlags.None, ref dummy);
+        }
+
+        public int Receive(Span<byte> buffer, SocketFlags flags)
+        {
+            EndPoint dummy = new IPEndPoint(IPAddress.Any, 0);
+
+            return ReceiveFrom(buffer, flags, ref dummy);
+        }
+
+        public int Receive(Span<byte> buffer, SocketFlags flags, out SocketError socketError)
+        {
+            EndPoint dummy = new IPEndPoint(IPAddress.Any, 0);
+
+            return ReceiveFrom(buffer, flags, out socketError, ref dummy);
+        }
+
+        public int ReceiveFrom(Span<byte> buffer, SocketFlags flags, ref EndPoint remoteEp)
+        {
+            // We just receive all packets meant for us anyways regardless of EP in the actual implementation.
+            // The point is mostly to return the endpoint that we got the data from.
+
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                throw new SocketException((int)WsaError.WSAECONNRESET);
+            }
+
+            lock (_receiveQueue)
+            {
+                if (_receiveQueue.Count > 0)
+                {
+                    return ReceiveFromQueue(buffer, flags, ref remoteEp);
+                }
+                else if (_readShutdown)
+                {
+                    return 0;
+                }
+                else if (!Blocking)
+                {
+                    throw new SocketException((int)WsaError.WSAEWOULDBLOCK);
+                }
+            }
+
+            int timeout = _receiveTimeout;
+
+            _receiveEvent.WaitOne(timeout == 0 ? -1 : timeout);
+
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                throw new SocketException((int)WsaError.WSAECONNRESET);
+            }
+
+            lock (_receiveQueue)
+            {
+                if (_receiveQueue.Count > 0)
+                {
+                    return ReceiveFromQueue(buffer, flags, ref remoteEp);
+                }
+                else if (_readShutdown)
+                {
+                    return 0;
+                }
+                else
+                {
+                    throw new SocketException((int)WsaError.WSAETIMEDOUT);
+                }
+            }
+        }
+
+        public int ReceiveFrom(Span<byte> buffer, SocketFlags flags, out SocketError socketError, ref EndPoint remoteEp)
+        {
+            // We just receive all packets meant for us anyways regardless of EP in the actual implementation.
+            // The point is mostly to return the endpoint that we got the data from.
+
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                socketError = SocketError.ConnectionReset;
+                return -1;
+            }
+
+            lock (_receiveQueue)
+            {
+                if (_receiveQueue.Count > 0)
+                {
+                    return ReceiveFromQueue(buffer, flags, out socketError, ref remoteEp);
+                }
+                else if (_readShutdown)
+                {
+                    socketError = SocketError.Success;
+                    return 0;
+                }
+                else if (!Blocking)
+                {
+                    throw new SocketException((int)WsaError.WSAEWOULDBLOCK);
+                }
+            }
+
+            int timeout = _receiveTimeout;
+
+            _receiveEvent.WaitOne(timeout == 0 ? -1 : timeout);
+
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                throw new SocketException((int)WsaError.WSAECONNRESET);
+            }
+
+            lock (_receiveQueue)
+            {
+                if (_receiveQueue.Count > 0)
+                {
+                    return ReceiveFromQueue(buffer, flags, out socketError, ref remoteEp);
+                }
+                else if (_readShutdown)
+                {
+                    socketError = SocketError.Success;
+                    return 0;
+                }
+                else
+                {
+                    socketError = SocketError.TimedOut;
+                    return -1;
+                }
+            }
+        }
+
+        private int ReceiveFromQueue(Span<byte> buffer, SocketFlags flags, ref EndPoint remoteEp)
+        {
+            int size = buffer.Length;
+
+            // Assumes we have the receive queue lock, and at least one item in the queue.
+            ProxyDataPacket packet = _receiveQueue.Peek();
+
+            remoteEp = GetEndpoint(packet.Header.Info.SourceIpV4, packet.Header.Info.SourcePort);
+
+            bool peek = (flags & SocketFlags.Peek) != 0;
+
+            int read;
+
+            if (packet.Data.Length > size)
+            {
+                read = size;
+
+                // Cannot fit in the output buffer. Copy up to what we've got.
+                packet.Data.AsSpan(0, size).CopyTo(buffer);
+
+                if (ProtocolType == ProtocolType.Udp)
+                {
+                    // Udp overflows, loses the data, then throws an exception.
+
+                    if (!peek)
+                    {
+                        _receiveQueue.Dequeue();
+                    }
+
+                    throw new SocketException((int)WsaError.WSAEMSGSIZE);
+                }
+                else if (ProtocolType == ProtocolType.Tcp)
+                {
+                    // Split the data at the buffer boundary. It will stay on the recieve queue.
+
+                    byte[] newData = new byte[packet.Data.Length - size];
+                    Array.Copy(packet.Data, size, newData, 0, newData.Length);
+
+                    packet.Data = newData;
+                }
+            }
+            else
+            {
+                read = packet.Data.Length;
+
+                packet.Data.AsSpan(0, packet.Data.Length).CopyTo(buffer);
+
+                if (!peek)
+                {
+                    _receiveQueue.Dequeue();
+                }
+            }
+
+            return read;
+        }
+
+        private int ReceiveFromQueue(Span<byte> buffer, SocketFlags flags, out SocketError socketError,
+            ref EndPoint remoteEp)
+        {
+            int size = buffer.Length;
+
+            // Assumes we have the receive queue lock, and at least one item in the queue.
+            ProxyDataPacket packet = _receiveQueue.Peek();
+
+            remoteEp = GetEndpoint(packet.Header.Info.SourceIpV4, packet.Header.Info.SourcePort);
+
+            bool peek = (flags & SocketFlags.Peek) != 0;
+
+            int read;
+
+            if (packet.Data.Length > size)
+            {
+                read = size;
+
+                // Cannot fit in the output buffer. Copy up to what we've got.
+                packet.Data.AsSpan(0, size).CopyTo(buffer);
+
+                if (ProtocolType == ProtocolType.Udp)
+                {
+                    // Udp overflows, loses the data, then throws an exception.
+
+                    if (!peek)
+                    {
+                        _receiveQueue.Dequeue();
+                    }
+
+                    socketError = SocketError.MessageSize;
+                    return -1;
+                }
+                else if (ProtocolType == ProtocolType.Tcp)
+                {
+                    // Split the data at the buffer boundary. It will stay on the recieve queue.
+
+                    byte[] newData = new byte[packet.Data.Length - size];
+                    Array.Copy(packet.Data, size, newData, 0, newData.Length);
+
+                    packet.Data = newData;
+                }
+            }
+            else
+            {
+                read = packet.Data.Length;
+
+                packet.Data.AsSpan(0, packet.Data.Length).CopyTo(buffer);
+
+                if (!peek)
+                {
+                    _receiveQueue.Dequeue();
+                }
+            }
+
+            socketError = SocketError.Success;
+
+            return read;
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer)
+        {
+            // Send to the remote host chosen when we "connect" or "accept".
+            if (!Connected)
+            {
+                throw new SocketException();
+            }
+
+            return SendTo(buffer, SocketFlags.None, RemoteEndPoint);
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer, SocketFlags flags)
+        {
+            // Send to the remote host chosen when we "connect" or "accept".
+            if (!Connected)
+            {
+                throw new SocketException();
+            }
+
+            return SendTo(buffer, flags, RemoteEndPoint);
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer, SocketFlags flags, out SocketError socketError)
+        {
+            // Send to the remote host chosen when we "connect" or "accept".
+            if (!Connected)
+            {
+                throw new SocketException();
+            }
+
+            return SendTo(buffer, flags, out socketError, RemoteEndPoint);
+        }
+
+        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags flags, EndPoint remoteEP)
+        {
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                throw new SocketException((int)WsaError.WSAECONNRESET);
+            }
+
+            IPEndPoint localEp = EnsureLocalEndpoint(false);
+
+            if (remoteEP is not IPEndPoint)
+            {
+                throw new NotSupportedException();
+            }
+
+            return _proxy.SendTo(buffer, flags, localEp, (IPEndPoint)remoteEP, ProtocolType);
+        }
+
+        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags flags, out SocketError socketError, EndPoint remoteEP)
+        {
+            if (!Connected && ProtocolType == ProtocolType.Tcp)
+            {
+                socketError = SocketError.ConnectionReset;
+                return -1;
+            }
+
+            IPEndPoint localEp = EnsureLocalEndpoint(false);
+
+            if (remoteEP is not IPEndPoint)
+            {
+                // throw new NotSupportedException();
+                socketError = SocketError.OperationNotSupported;
+                return -1;
+            }
+
+            socketError = SocketError.Success;
+
+            return _proxy.SendTo(buffer, flags, localEp, (IPEndPoint)remoteEP, ProtocolType);
+        }
+
+        public bool Poll(int microSeconds, SelectMode mode)
+        {
+            return mode switch
+            {
+                SelectMode.SelectRead => Readable,
+                SelectMode.SelectWrite => Writable,
+                SelectMode.SelectError => Error,
+                _ => false
+            };
+        }
+
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
+        {
+            if (optionLevel != SocketOptionLevel.Socket)
+            {
+                throw new NotImplementedException();
+            }
+
+            switch (optionName)
+            {
+                case SocketOptionName.SendTimeout:
+                    //_sendTimeout = optionValue;
+                    break;
+                case SocketOptionName.ReceiveTimeout:
+                    _receiveTimeout = optionValue;
+                    break;
+                case SocketOptionName.Broadcast:
+                    _broadcast = optionValue != 0;
+                    break;
+            }
+
+            lock (_socketOptions)
+            {
+                _socketOptions[optionName] = optionValue;
+            }
+        }
+
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue)
+        {
+            // Just linger uses this for now in BSD, which we ignore.
+        }
+
+        public void Shutdown(SocketShutdown how)
+        {
+            switch (how)
+            {
+                case SocketShutdown.Both:
+                    _readShutdown = true;
+                    // _writeShutdown = true;
+                    break;
+                case SocketShutdown.Receive:
+                    _readShutdown = true;
+                    break;
+                case SocketShutdown.Send:
+                    // _writeShutdown = true;
+                    break;
+            }
+        }
+
+        public void ProxyDestroyed()
+        {
+            // Do nothing, for now. Will likely be more useful with TCP.
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyClient.cs
@@ -1,0 +1,80 @@
+﻿using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy;
+using System.Net.Sockets;
+using System.Threading;
+using TcpClient = NetCoreServer.TcpClient;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    class P2pProxyClient : TcpClient, IProxyClient
+    {
+        private const int FailureTimeout = 4000;
+        public ProxyConfig ProxyConfig { get; private set; }
+        private readonly RyuLdnProtocol _protocol;
+        private readonly ManualResetEvent _connected = new ManualResetEvent(false);
+        private readonly ManualResetEvent _ready = new ManualResetEvent(false);
+        private readonly AutoResetEvent _error = new AutoResetEvent(false);
+
+        public P2pProxyClient(string address, int port) : base(address, port)
+        {
+            if (ProxyHelpers.SupportsNoDelay())
+            {
+                OptionNoDelay = true;
+            }
+
+            _protocol = new RyuLdnProtocol();
+            _protocol.ProxyConfig += HandleProxyConfig;
+            ConnectAsync();
+        }
+
+        protected override void OnConnected()
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"Proxy TCP client connected a new session with Id {Id}");
+            _connected.Set();
+        }
+
+        protected override void OnDisconnected()
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"Proxy TCP client disconnected a session with Id {Id}");
+            SocketHelpers.UnregisterProxy();
+            _connected.Reset();
+        }
+
+        protected override void OnReceived(byte[] buffer, long offset, long size)
+        {
+            _protocol.Read(buffer, (int)offset, (int)size);
+        }
+
+        protected override void OnError(SocketError error)
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"Proxy TCP client caught an error with code {error}");
+            _error.Set();
+        }
+
+        private void HandleProxyConfig(LdnHeader header, ProxyConfig config)
+        {
+            ProxyConfig = config;
+            SocketHelpers.RegisterProxy(new LdnProxy(config, this, _protocol));
+            _ready.Set();
+        }
+
+        public bool EnsureProxyReady()
+        {
+            return _ready.WaitOne(FailureTimeout);
+        }
+
+        public bool PerformAuth(ExternalProxyConfig config)
+        {
+            bool signalled = _connected.WaitOne(FailureTimeout);
+            if (!signalled)
+            {
+                return false;
+            }
+
+            SendAsync(_protocol.Encode(PacketId.ExternalProxy, config));
+            return true;
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyServer.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxyServer.cs
@@ -1,0 +1,387 @@
+﻿using NetCoreServer;
+using Open.Nat;
+using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    class P2pProxyServer : TcpServer, IDisposable
+    {
+        public const ushort PrivatePortBase = 39990;
+        public const int PrivatePortRange = 10;
+
+        private const ushort PublicPortBase = 39990;
+        private const int PublicPortRange = 10;
+
+        private const ushort PortLeaseLength = 60;
+        private const ushort PortLeaseRenew = 50;
+
+        private const ushort AuthWaitSeconds = 1;
+
+        private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
+
+        public ushort PrivatePort { get; }
+
+        private ushort _publicPort;
+
+        private bool _disposed;
+        private readonly CancellationTokenSource _disposedCancellation = new CancellationTokenSource();
+
+        private NatDevice _natDevice;
+        private Mapping _portMapping;
+
+        private readonly List<P2pProxySession> _players = new List<P2pProxySession>();
+
+        private readonly List<ExternalProxyToken> _waitingTokens = new List<ExternalProxyToken>();
+        private readonly AutoResetEvent _tokenEvent = new AutoResetEvent(false);
+
+        private uint _broadcastAddress;
+
+        private readonly LdnMasterProxyClient _master;
+        private readonly RyuLdnProtocol _masterProtocol;
+        private readonly RyuLdnProtocol _protocol;
+
+        public P2pProxyServer(LdnMasterProxyClient master, ushort port, RyuLdnProtocol masterProtocol) : base(
+            IPAddress.Any, port)
+        {
+            if (ProxyHelpers.SupportsNoDelay())
+            {
+                OptionNoDelay = true;
+            }
+
+            PrivatePort = port;
+
+            _master = master;
+            _masterProtocol = masterProtocol;
+
+            _masterProtocol.ExternalProxyState += HandleStateChange;
+            _masterProtocol.ExternalProxyToken += HandleToken;
+
+            _protocol = new RyuLdnProtocol();
+        }
+
+        private void HandleToken(LdnHeader header, ExternalProxyToken token)
+        {
+            _lock.EnterWriteLock();
+
+            _waitingTokens.Add(token);
+
+            _lock.ExitWriteLock();
+
+            _tokenEvent.Set();
+        }
+
+        private void HandleStateChange(LdnHeader header, ExternalProxyConnectionState state)
+        {
+            if (!state.Connected)
+            {
+                _lock.EnterWriteLock();
+
+                _waitingTokens.RemoveAll(token => token.VirtualIp == state.IpAddress);
+
+                _players.RemoveAll(player =>
+                {
+                    if (player.VirtualIpAddress == state.IpAddress)
+                    {
+                        player.DisconnectAndStop();
+
+                        return true;
+                    }
+
+                    return false;
+                });
+
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public void Configure(ProxyConfig config)
+        {
+            _broadcastAddress = config.ProxyIp | (~config.ProxySubnetMask);
+        }
+
+        public async Task<ushort> NatPunch()
+        {
+            NatDiscoverer discoverer = new NatDiscoverer();
+            CancellationTokenSource cts = new CancellationTokenSource(1000);
+
+            NatDevice device;
+
+            try
+            {
+                device = await discoverer.DiscoverDeviceAsync(PortMapper.Upnp, cts);
+            }
+            catch (NatDeviceNotFoundException)
+            {
+                return 0;
+            }
+
+            _publicPort = PublicPortBase;
+
+            for (int i = 0; i < PublicPortRange; i++)
+            {
+                try
+                {
+                    _portMapping = new Mapping(Protocol.Tcp, PrivatePort, _publicPort, PortLeaseLength,
+                        "Ryujinx Local Multiplayer");
+
+                    await device.CreatePortMapAsync(_portMapping);
+
+                    break;
+                }
+                catch (MappingException)
+                {
+                    _publicPort++;
+                }
+                catch (Exception)
+                {
+                    return 0;
+                }
+
+                if (i == PublicPortRange - 1)
+                {
+                    _publicPort = 0;
+                }
+            }
+
+            if (_publicPort != 0)
+            {
+                _ = Task.Delay(PortLeaseRenew * 1000, _disposedCancellation.Token)
+                    .ContinueWith((task) => Task.Run(RefreshLease));
+            }
+
+            _natDevice = device;
+
+            return _publicPort;
+        }
+
+        // Proxy handlers
+
+        private void RouteMessage(P2pProxySession sender, ref ProxyInfo info, Action<P2pProxySession> action)
+        {
+            if (info.SourceIpV4 == 0)
+            {
+                // If they sent from a connection bound on 0.0.0.0, make others see it as them.
+                info.SourceIpV4 = sender.VirtualIpAddress;
+            }
+            else if (info.SourceIpV4 != sender.VirtualIpAddress)
+            {
+                // Can't pretend to be somebody else.
+                return;
+            }
+
+            uint destIp = info.DestIpV4;
+
+            if (destIp == 0xc0a800ff)
+            {
+                destIp = _broadcastAddress;
+            }
+
+            bool isBroadcast = destIp == _broadcastAddress;
+
+            _lock.EnterReadLock();
+
+            if (isBroadcast)
+            {
+                _players.ForEach(player =>
+                {
+                    action(player);
+                });
+            }
+            else
+            {
+                P2pProxySession target = _players.FirstOrDefault(player => player.VirtualIpAddress == destIp);
+
+                if (target != null)
+                {
+                    action(target);
+                }
+            }
+
+            _lock.ExitReadLock();
+        }
+
+        public void HandleProxyDisconnect(P2pProxySession sender, LdnHeader header, ProxyDisconnectMessage message)
+        {
+            RouteMessage(sender, ref message.Info, (target) =>
+            {
+                target.SendAsync(sender.Protocol.Encode(PacketId.ProxyDisconnect, message));
+            });
+        }
+
+        public void HandleProxyData(P2pProxySession sender, LdnHeader header, ProxyDataHeader message, byte[] data)
+        {
+            RouteMessage(sender, ref message.Info, (target) =>
+            {
+                target.SendAsync(sender.Protocol.Encode(PacketId.ProxyData, message, data));
+            });
+        }
+
+        public void HandleProxyConnectReply(P2pProxySession sender, LdnHeader header, ProxyConnectResponse message)
+        {
+            RouteMessage(sender, ref message.Info, (target) =>
+            {
+                target.SendAsync(sender.Protocol.Encode(PacketId.ProxyConnectReply, message));
+            });
+        }
+
+        public void HandleProxyConnect(P2pProxySession sender, LdnHeader header, ProxyConnectRequest message)
+        {
+            RouteMessage(sender, ref message.Info, (target) =>
+            {
+                target.SendAsync(sender.Protocol.Encode(PacketId.ProxyConnect, message));
+            });
+        }
+
+        // End proxy handlers
+
+        private async Task RefreshLease()
+        {
+            if (_disposed || _natDevice == null)
+            {
+                return;
+            }
+
+            try
+            {
+                await _natDevice.CreatePortMapAsync(_portMapping);
+            }
+            catch (Exception)
+            {
+            }
+
+            _ = Task.Delay(PortLeaseRenew, _disposedCancellation.Token).ContinueWith((task) => Task.Run(RefreshLease));
+        }
+
+        public bool TryRegisterUser(P2pProxySession session, ExternalProxyConfig config)
+        {
+            _lock.EnterWriteLock();
+
+            // Attempt to find matching configuration. If we don't find one, wait for a bit and try again.
+            // Woken by new tokens coming in from the master server.
+
+            IPAddress address = (session.Socket.RemoteEndPoint as IPEndPoint).Address;
+            byte[] addressBytes = ProxyHelpers.AddressTo16Byte(address);
+
+            long time;
+            long endTime = Stopwatch.GetTimestamp() + Stopwatch.Frequency * AuthWaitSeconds;
+
+            do
+            {
+                for (int i = 0; i < _waitingTokens.Count; i++)
+                {
+                    ExternalProxyToken waitToken = _waitingTokens[i];
+
+                    // Allow any client that has a private IP to connect. (indicated by the server as all 0 in the token)
+
+                    bool isPrivate = waitToken.PhysicalIp.AsSpan().SequenceEqual(new byte[16]);
+                    bool ipEqual = isPrivate || waitToken.AddressFamily == address.AddressFamily &&
+                        waitToken.PhysicalIp.AsSpan().SequenceEqual(addressBytes);
+
+                    if (ipEqual && waitToken.Token.AsSpan().SequenceEqual(config.Token.AsSpan()))
+                    {
+                        // This is a match.
+
+                        _waitingTokens.RemoveAt(i);
+
+                        session.SetIpv4(waitToken.VirtualIp);
+
+                        ProxyConfig pconfig = new ProxyConfig
+                        {
+                            ProxyIp = session.VirtualIpAddress, ProxySubnetMask = 0xFFFF0000 // TODO: Use from server.
+                        };
+
+                        if (_players.Count == 0)
+                        {
+                            Configure(pconfig);
+                        }
+
+                        _players.Add(session);
+
+                        session.SendAsync(_protocol.Encode(PacketId.ProxyConfig, pconfig));
+
+                        _lock.ExitWriteLock();
+
+                        return true;
+                    }
+                }
+
+                // Couldn't find the token.
+                // It may not have arrived yet, so wait for one to arrive.
+
+                _lock.ExitWriteLock();
+
+                time = Stopwatch.GetTimestamp();
+                int remainingMs = (int)((endTime - time) / (Stopwatch.Frequency / 1000));
+
+                if (remainingMs < 0)
+                {
+                    remainingMs = 0;
+                }
+
+                _tokenEvent.WaitOne(remainingMs);
+
+                _lock.EnterWriteLock();
+            } while (time < endTime);
+
+            _lock.ExitWriteLock();
+
+            return false;
+        }
+
+        public void DisconnectProxyClient(P2pProxySession session)
+        {
+            _lock.EnterWriteLock();
+
+            bool removed = _players.Remove(session);
+
+            if (removed)
+            {
+                _master.SendAsync(_masterProtocol.Encode(PacketId.ExternalProxyState,
+                    new ExternalProxyConnectionState { IpAddress = session.VirtualIpAddress, Connected = false }));
+            }
+
+            _lock.ExitWriteLock();
+        }
+
+        public new void Dispose()
+        {
+            base.Dispose();
+
+            _disposed = true;
+            _disposedCancellation.Cancel();
+
+            try
+            {
+                Task delete = _natDevice?.DeletePortMapAsync(new Mapping(Protocol.Tcp, PrivatePort, _publicPort, 60,
+                    "Ryujinx Local Multiplayer"));
+
+                // Just absorb any exceptions.
+                delete?.ContinueWith((task) => { });
+            }
+            catch (Exception)
+            {
+                // Fail silently.
+            }
+        }
+
+        protected override TcpSession CreateSession()
+        {
+            return new P2pProxySession(this);
+        }
+
+        protected override void OnError(SocketError error)
+        {
+            Logger.Info?.PrintMsg(LogClass.ServiceLdn, $"Proxy TCP server caught an error with code {error}");
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxySession.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/P2pProxySession.cs
@@ -1,0 +1,84 @@
+﻿using NetCoreServer;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using System;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    class P2pProxySession : TcpSession
+    {
+        public uint VirtualIpAddress { get; private set; }
+        public RyuLdnProtocol Protocol { get; }
+        private readonly P2pProxyServer _parent;
+        private bool _masterClosed;
+
+        public P2pProxySession(P2pProxyServer server) : base(server)
+        {
+            _parent = server;
+            Protocol = new RyuLdnProtocol();
+            Protocol.ProxyDisconnect += HandleProxyDisconnect;
+            Protocol.ProxyData += HandleProxyData;
+            Protocol.ProxyConnectReply += HandleProxyConnectReply;
+            Protocol.ProxyConnect += HandleProxyConnect;
+            Protocol.ExternalProxy += HandleAuthentication;
+        }
+
+        private void HandleAuthentication(LdnHeader header, ExternalProxyConfig token)
+        {
+            if (!_parent.TryRegisterUser(this, token))
+            {
+                Disconnect();
+            }
+        }
+
+        public void SetIpv4(uint ip)
+        {
+            VirtualIpAddress = ip;
+        }
+
+        public void DisconnectAndStop()
+        {
+            _masterClosed = true;
+            Disconnect();
+        }
+
+        protected override void OnDisconnected()
+        {
+            if (!_masterClosed)
+            {
+                _parent.DisconnectProxyClient(this);
+            }
+        }
+
+        protected override void OnReceived(byte[] buffer, long offset, long size)
+        {
+            try
+            {
+                Protocol.Read(buffer, (int)offset, (int)size);
+            }
+            catch (Exception)
+            {
+                Disconnect();
+            }
+        }
+
+        private void HandleProxyDisconnect(LdnHeader header, ProxyDisconnectMessage message)
+        {
+            _parent.HandleProxyDisconnect(this, header, message);
+        }
+
+        private void HandleProxyData(LdnHeader header, ProxyDataHeader message, byte[] data)
+        {
+            _parent.HandleProxyData(this, header, message, data);
+        }
+
+        private void HandleProxyConnectReply(LdnHeader header, ProxyConnectResponse data)
+        {
+            _parent.HandleProxyConnectReply(this, header, data);
+        }
+
+        private void HandleProxyConnect(LdnHeader header, ProxyConnectRequest message)
+        {
+            _parent.HandleProxyConnect(this, header, message);
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/ProxyHelpers.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Proxy/ProxyHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Net;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy
+{
+    static class ProxyHelpers
+    {
+        public static byte[] AddressTo16Byte(IPAddress address)
+        {
+            byte[] ipBytes = new byte[16];
+            byte[] srcBytes = address.GetAddressBytes();
+            Array.Copy(srcBytes, 0, ipBytes, 0, srcBytes.Length);
+            return ipBytes;
+        }
+
+        public static bool SupportsNoDelay()
+        {
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/RyuLdnProtocol.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/RyuLdnProtocol.cs
@@ -1,0 +1,323 @@
+﻿using Ryujinx.Common.Utilities;
+using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types;
+using System;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu
+{
+    class RyuLdnProtocol
+    {
+        private const byte CurrentProtocolVersion = 1;
+        private const int Magic = ('R' << 0) | ('L' << 8) | ('D' << 16) | ('N' << 24);
+        private const int MaxPacketSize = 131072;
+        private readonly int _headerSize = Marshal.SizeOf<LdnHeader>();
+        private readonly byte[] _buffer = new byte[MaxPacketSize];
+
+        private int _bufferEnd = 0;
+
+        // Client Packets.
+        public event Action<LdnHeader, InitializeMessage> Initialize;
+        public event Action<LdnHeader, PassphraseMessage> Passphrase;
+        public event Action<LdnHeader, NetworkInfo> Connected;
+        public event Action<LdnHeader, NetworkInfo> SyncNetwork;
+        public event Action<LdnHeader, NetworkInfo> ScanReply;
+        public event Action<LdnHeader> ScanReplyEnd;
+
+        public event Action<LdnHeader, DisconnectMessage> Disconnected;
+
+        // External Proxy Packets.
+        public event Action<LdnHeader, ExternalProxyConfig> ExternalProxy;
+        public event Action<LdnHeader, ExternalProxyConnectionState> ExternalProxyState;
+
+        public event Action<LdnHeader, ExternalProxyToken> ExternalProxyToken;
+
+        // Server Packets.
+        public event Action<LdnHeader, CreateAccessPointRequest, byte[]> CreateAccessPoint;
+        public event Action<LdnHeader, CreateAccessPointPrivateRequest, byte[]> CreateAccessPointPrivate;
+        public event Action<LdnHeader, RejectRequest> Reject;
+        public event Action<LdnHeader> RejectReply;
+        public event Action<LdnHeader, SetAcceptPolicyRequest> SetAcceptPolicy;
+        public event Action<LdnHeader, byte[]> SetAdvertiseData;
+        public event Action<LdnHeader, ConnectRequest> Connect;
+        public event Action<LdnHeader, ConnectPrivateRequest> ConnectPrivate;
+
+        public event Action<LdnHeader, ScanFilter> Scan;
+
+        // Proxy Packets.
+        public event Action<LdnHeader, ProxyConfig> ProxyConfig;
+        public event Action<LdnHeader, ProxyConnectRequest> ProxyConnect;
+        public event Action<LdnHeader, ProxyConnectResponse> ProxyConnectReply;
+        public event Action<LdnHeader, ProxyDataHeader, byte[]> ProxyData;
+
+        public event Action<LdnHeader, ProxyDisconnectMessage> ProxyDisconnect;
+
+        // Lifecycle Packets.
+        public event Action<LdnHeader, NetworkErrorMessage> NetworkError;
+        public event Action<LdnHeader, PingMessage> Ping;
+        public RyuLdnProtocol() { }
+
+        public void Reset()
+        {
+            _bufferEnd = 0;
+        }
+
+        public void Read(byte[] data, int offset, int size)
+        {
+            int index = 0;
+            while (index < size)
+            {
+                if (_bufferEnd < _headerSize)
+                {
+                    // Assemble the header first.
+                    int copyable = Math.Min(size - index, Math.Min(size, _headerSize - _bufferEnd));
+                    Array.Copy(data, index + offset, _buffer, _bufferEnd, copyable);
+                    index += copyable;
+                    _bufferEnd += copyable;
+                }
+
+                if (_bufferEnd >= _headerSize)
+                {
+                    // The header is available. Make sure we received all the data (size specified in the header)
+                    LdnHeader ldnHeader = MemoryMarshal.Cast<byte, LdnHeader>(_buffer)[0];
+                    if (ldnHeader.Magic != Magic)
+                    {
+                        throw new InvalidOperationException("Invalid magic number in received packet.");
+                    }
+
+                    if (ldnHeader.Version != CurrentProtocolVersion)
+                    {
+                        throw new InvalidOperationException(
+                            $"Protocol version mismatch. Expected ${CurrentProtocolVersion}, was ${ldnHeader.Version}.");
+                    }
+
+                    int finalSize = _headerSize + ldnHeader.DataSize;
+                    if (finalSize >= MaxPacketSize)
+                    {
+                        throw new InvalidOperationException($"Max packet size {MaxPacketSize} exceeded.");
+                    }
+
+                    int copyable = Math.Min(size - index, Math.Min(size, finalSize - _bufferEnd));
+                    Array.Copy(data, index + offset, _buffer, _bufferEnd, copyable);
+                    index += copyable;
+                    _bufferEnd += copyable;
+                    if (finalSize == _bufferEnd)
+                    {
+                        // The full packet has been retrieved. Send it to be decoded.
+                        byte[] ldnData = new byte[ldnHeader.DataSize];
+                        Array.Copy(_buffer, _headerSize, ldnData, 0, ldnData.Length);
+                        DecodeAndHandle(ldnHeader, ldnData);
+                        Reset();
+                    }
+                }
+            }
+        }
+
+        private (T, byte[]) ParseWithData<T>(byte[] data) where T : struct
+        {
+            T str = default;
+            int size = Marshal.SizeOf(str);
+            byte[] remainder = new byte[data.Length - size];
+            if (remainder.Length > 0)
+            {
+                Array.Copy(data, size, remainder, 0, remainder.Length);
+            }
+
+            return (MemoryMarshal.Read<T>(data), remainder);
+        }
+
+        private void DecodeAndHandle(LdnHeader header, byte[] data)
+        {
+            switch ((PacketId)header.Type)
+            {
+                // Client Packets.
+                case PacketId.Initialize:
+                    {
+                        Initialize?.Invoke(header, MemoryMarshal.Read<InitializeMessage>(data));
+                        break;
+                    }
+                case PacketId.Passphrase:
+                    {
+                        Passphrase?.Invoke(header, MemoryMarshal.Read<PassphraseMessage>(data));
+                        break;
+                    }
+                case PacketId.Connected:
+                    {
+                        Connected?.Invoke(header, MemoryMarshal.Read<NetworkInfo>(data));
+                        break;
+                    }
+                case PacketId.SyncNetwork:
+                    {
+                        SyncNetwork?.Invoke(header, MemoryMarshal.Read<NetworkInfo>(data));
+                        break;
+                    }
+                case PacketId.ScanReply:
+                    {
+                        ScanReply?.Invoke(header, MemoryMarshal.Read<NetworkInfo>(data));
+                        break;
+                    }
+                case PacketId.ScanReplyEnd:
+                    {
+                        ScanReplyEnd?.Invoke(header);
+                        break;
+                    }
+                case PacketId.Disconnect:
+                    {
+                        Disconnected?.Invoke(header, MemoryMarshal.Read<DisconnectMessage>(data));
+                        break;
+                    }
+                // External Proxy Packets.
+                case PacketId.ExternalProxy:
+                    {
+                        ExternalProxy?.Invoke(header, MemoryMarshal.Read<ExternalProxyConfig>(data));
+                        break;
+                    }
+                case PacketId.ExternalProxyState:
+                    {
+                        ExternalProxyState?.Invoke(header, MemoryMarshal.Read<ExternalProxyConnectionState>(data));
+                        break;
+                    }
+                case PacketId.ExternalProxyToken:
+                    {
+                        ExternalProxyToken?.Invoke(header, MemoryMarshal.Read<ExternalProxyToken>(data));
+                        break;
+                    }
+                // Server Packets.
+                case PacketId.CreateAccessPoint:
+                    {
+                        (CreateAccessPointRequest packet, byte[] extraData) =
+                            ParseWithData<CreateAccessPointRequest>(data);
+                        CreateAccessPoint?.Invoke(header, packet, extraData);
+                        break;
+                    }
+                case PacketId.CreateAccessPointPrivate:
+                    {
+                        (CreateAccessPointPrivateRequest packet, byte[] extraData) =
+                            ParseWithData<CreateAccessPointPrivateRequest>(data);
+                        CreateAccessPointPrivate?.Invoke(header, packet, extraData);
+                        break;
+                    }
+                case PacketId.Reject:
+                    {
+                        Reject?.Invoke(header, MemoryMarshal.Read<RejectRequest>(data));
+                        break;
+                    }
+                case PacketId.RejectReply:
+                    {
+                        RejectReply?.Invoke(header);
+                        break;
+                    }
+                case PacketId.SetAcceptPolicy:
+                    {
+                        SetAcceptPolicy?.Invoke(header, MemoryMarshal.Read<SetAcceptPolicyRequest>(data));
+                        break;
+                    }
+                case PacketId.SetAdvertiseData:
+                    {
+                        SetAdvertiseData?.Invoke(header, data);
+                        break;
+                    }
+                case PacketId.Connect:
+                    {
+                        Connect?.Invoke(header, MemoryMarshal.Read<ConnectRequest>(data));
+                        break;
+                    }
+                case PacketId.ConnectPrivate:
+                    {
+                        ConnectPrivate?.Invoke(header, MemoryMarshal.Read<ConnectPrivateRequest>(data));
+                        break;
+                    }
+                case PacketId.Scan:
+                    {
+                        Scan?.Invoke(header, MemoryMarshal.Read<ScanFilter>(data));
+                        break;
+                    }
+                // Proxy Packets
+                case PacketId.ProxyConfig:
+                    {
+                        ProxyConfig?.Invoke(header, MemoryMarshal.Read<ProxyConfig>(data));
+                        break;
+                    }
+                case PacketId.ProxyConnect:
+                    {
+                        ProxyConnect?.Invoke(header, MemoryMarshal.Read<ProxyConnectRequest>(data));
+                        break;
+                    }
+                case PacketId.ProxyConnectReply:
+                    {
+                        ProxyConnectReply?.Invoke(header, MemoryMarshal.Read<ProxyConnectResponse>(data));
+                        break;
+                    }
+                case PacketId.ProxyData:
+                    {
+                        (ProxyDataHeader packet, byte[] extraData) = ParseWithData<ProxyDataHeader>(data);
+                        ProxyData?.Invoke(header, packet, extraData);
+                        break;
+                    }
+                case PacketId.ProxyDisconnect:
+                    {
+                        ProxyDisconnect?.Invoke(header, MemoryMarshal.Read<ProxyDisconnectMessage>(data));
+                        break;
+                    }
+                // Lifecycle Packets.
+                case PacketId.Ping:
+                    {
+                        Ping?.Invoke(header, MemoryMarshal.Read<PingMessage>(data));
+                        break;
+                    }
+                case PacketId.NetworkError:
+                    {
+                        NetworkError?.Invoke(header, MemoryMarshal.Read<NetworkErrorMessage>(data));
+                        break;
+                    }
+                default:
+                    break;
+            }
+        }
+
+        private static LdnHeader GetHeader(PacketId type, int dataSize)
+        {
+            return new LdnHeader()
+            {
+                Magic = Magic, Version = CurrentProtocolVersion, Type = (byte)type, DataSize = dataSize
+            };
+        }
+
+        public byte[] Encode(PacketId type)
+        {
+            LdnHeader header = GetHeader(type, 0);
+            return SpanHelpers.AsSpan<LdnHeader, byte>(ref header).ToArray();
+        }
+
+        public byte[] Encode(PacketId type, byte[] data)
+        {
+            LdnHeader header = GetHeader(type, data.Length);
+            byte[] result = SpanHelpers.AsSpan<LdnHeader, byte>(ref header).ToArray();
+            Array.Resize(ref result, result.Length + data.Length);
+            Array.Copy(data, 0, result, Marshal.SizeOf<LdnHeader>(), data.Length);
+            return result;
+        }
+
+        public byte[] Encode<T>(PacketId type, T packet) where T : unmanaged
+        {
+            byte[] packetData = SpanHelpers.AsSpan<T, byte>(ref packet).ToArray();
+            LdnHeader header = GetHeader(type, packetData.Length);
+            byte[] result = SpanHelpers.AsSpan<LdnHeader, byte>(ref header).ToArray();
+            Array.Resize(ref result, result.Length + packetData.Length);
+            Array.Copy(packetData, 0, result, Marshal.SizeOf<LdnHeader>(), packetData.Length);
+            return result;
+        }
+
+        public byte[] Encode<T>(PacketId type, T packet, byte[] data) where T : unmanaged
+        {
+            byte[] packetData = SpanHelpers.AsSpan<T, byte>(ref packet).ToArray();
+            LdnHeader header = GetHeader(type, packetData.Length + data.Length);
+            byte[] result = SpanHelpers.AsSpan<LdnHeader, byte>(ref header).ToArray();
+            Array.Resize(ref result, result.Length + packetData.Length + data.Length);
+            Array.Copy(packetData, 0, result, Marshal.SizeOf<LdnHeader>(), packetData.Length);
+            Array.Copy(data, 0, result, Marshal.SizeOf<LdnHeader>() + packetData.Length, data.Length);
+            return result;
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/DisconnectMessage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/DisconnectMessage.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x4)]
+    struct DisconnectMessage
+    {
+        public uint DisconnectIP;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyConfig.cs
@@ -1,0 +1,19 @@
+﻿using Ryujinx.Common.Memory;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// Sent by the server to point a client towards an external server being used as a proxy.
+    /// The client then forwards this to the external proxy after connecting, to verify the connection worked.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x26, Pack = 1)]
+    struct ExternalProxyConfig
+    {
+        public Array16<byte> ProxyIp;
+        public AddressFamily AddressFamily;
+        public ushort ProxyPort;
+        public Array16<byte> Token;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyConnectionState.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyConnectionState.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// Indicates a change in connection state for the given client.
+    /// Is sent to notify the master server when connection is first established.
+    /// Can be sent by the external proxy to the master server to notify it of a proxy disconnect.
+    /// Can be sent by the master server to notify the external proxy of a user leaving a room.
+    /// Both will result in a force kick.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x8, Pack = 4)]
+    struct ExternalProxyConnectionState
+    {
+        public uint IpAddress;
+        public bool Connected;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyToken.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ExternalProxyToken.cs
@@ -1,0 +1,20 @@
+﻿using Ryujinx.Common.Memory;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// Sent by the master server to an external proxy to tell them someone is going to connect.
+    /// This drives authentication, and lets the proxy know what virtual IP to give to each joiner,
+    /// as these are managed by the master server.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x28)]
+    struct ExternalProxyToken
+    {
+        public uint VirtualIp;
+        public Array16<byte> Token;
+        public Array16<byte> PhysicalIp;
+        public AddressFamily AddressFamily;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/InitializeMessage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/InitializeMessage.cs
@@ -1,0 +1,20 @@
+﻿using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// This message is first sent by the client to identify themselves.
+    /// If the server has a token+mac combo that matches the submission, then they are returned their new ID and mac address. (the mac is also reassigned to the new id)
+    /// Otherwise, they are returned a random mac address.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x16)]
+    struct InitializeMessage
+    {
+        // All 0 if we don't have an ID yet.
+        public Array16<byte> Id;
+
+        // All 0 if we don't have a mac yet.
+        public Array6<byte> MacAddress;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/LdnHeader.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/LdnHeader.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0xA)]
+    struct LdnHeader
+    {
+        public uint Magic;
+        public byte Type;
+        public byte Version;
+        public int DataSize;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PacketId.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PacketId.cs
@@ -1,0 +1,32 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    enum PacketId
+    {
+        Initialize,
+        Passphrase,
+        CreateAccessPoint,
+        CreateAccessPointPrivate,
+        ExternalProxy,
+        ExternalProxyToken,
+        ExternalProxyState,
+        SyncNetwork,
+        Reject,
+        RejectReply,
+        Scan,
+        ScanReply,
+        ScanReplyEnd,
+        Connect,
+        ConnectPrivate,
+        Connected,
+        Disconnect,
+        ProxyConfig,
+        ProxyConnect,
+        ProxyConnectReply,
+        ProxyData,
+        ProxyDisconnect,
+        SetAcceptPolicy,
+        SetAdvertiseData,
+        Ping = 254,
+        NetworkError = 255
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PassphraseMessage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PassphraseMessage.cs
@@ -1,0 +1,11 @@
+﻿using Ryujinx.Common.Memory;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x80)]
+    struct PassphraseMessage
+    {
+        public Array128<byte> Passphrase;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PingMessage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/PingMessage.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x2)]
+    struct PingMessage
+    {
+        public byte Requester;
+        public byte Id;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyConnectRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyConnectRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    struct ProxyConnectRequest
+    {
+        public ProxyInfo Info;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyConnectResponse.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyConnectResponse.cs
@@ -1,0 +1,10 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x10)]
+    struct ProxyConnectResponse
+    {
+        public ProxyInfo Info;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDataHeader.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDataHeader.cs
@@ -1,0 +1,14 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// Represents data sent over a transport layer.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x14)]
+    struct ProxyDataHeader
+    {
+        public ProxyInfo Info;
+        public uint DataLength; // Followed by the data with the specified byte length.
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDataPacket.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDataPacket.cs
@@ -1,0 +1,8 @@
+﻿namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    class ProxyDataPacket
+    {
+        public ProxyDataHeader Header;
+        public byte[] Data;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDisconnectMessage.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyDisconnectMessage.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x14)]
+    struct ProxyDisconnectMessage
+    {
+        public ProxyInfo Info;
+        public int DisconnectReason;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyInfo.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/ProxyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    /// <summary>
+    /// Information included in all proxied communication.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential, Size = 0x10, Pack = 1)]
+    struct ProxyInfo
+    {
+        public uint SourceIpV4;
+        public ushort SourcePort;
+        public uint DestIpV4;
+        public ushort DestPort;
+        public ProtocolType Protocol;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/RejectRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/RejectRequest.cs
@@ -1,0 +1,18 @@
+﻿using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+    struct RejectRequest
+    {
+        public uint NodeId;
+        public DisconnectReason DisconnectReason;
+
+        public RejectRequest(DisconnectReason disconnectReason, uint nodeId)
+        {
+            DisconnectReason = disconnectReason;
+            NodeId = nodeId;
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/RyuNetworkConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/RyuNetworkConfig.cs
@@ -1,0 +1,21 @@
+﻿using Ryujinx.Common.Memory;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x28, Pack = 1)]
+    struct RyuNetworkConfig
+    {
+        public Array16<byte> GameVersion;
+
+        // PrivateIp is included for external proxies for the case where a client attempts to join from
+        // their own LAN. UPnP forwarding can fail when connecting devices on the same network over the public IP,
+        // so if their public IP is identical, the internal address should be sent instead.
+        // The fields below are 0 if not hosting a p2p proxy.
+        public Array16<byte> PrivateIp;
+        public AddressFamily AddressFamily;
+        public ushort ExternalProxyPort;
+        public ushort InternalProxyPort;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/SetAcceptPolicyRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/LdnRyu/Types/SetAcceptPolicyRequest.cs
@@ -1,0 +1,11 @@
+﻿using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x1, Pack = 1)]
+    struct SetAcceptPolicyRequest
+    {
+        public AcceptPolicy StationAcceptPolicy;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Station.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Station.cs
@@ -13,6 +13,8 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
         private readonly IUserLocalCommunicationService _parent;
 
         public bool Connected { get; private set; }
+        
+        public ProxyConfig Config => _parent.NetworkClient.Config;
 
         public Station(IUserLocalCommunicationService parent)
         {
@@ -48,9 +50,12 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator
 
         public void Dispose()
         {
-            _parent.NetworkClient.DisconnectNetwork();
+            if (_parent.NetworkClient != null)
+            {
+                _parent.NetworkClient.DisconnectNetwork();
 
-            _parent.NetworkClient.NetworkChange -= NetworkChanged;
+                _parent.NetworkClient.NetworkChange -= NetworkChanged;
+            }
         }
 
         private ResultCode NetworkErrorToResult(NetworkError error)

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/CreateAccessPointPrivateRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/CreateAccessPointPrivateRequest.cs
@@ -1,4 +1,5 @@
 using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types
@@ -14,5 +15,7 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types
         public UserConfig UserConfig;
         public NetworkConfig NetworkConfig;
         public AddressList AddressList;
+        
+        public RyuNetworkConfig RyuNetworkConfig;
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/CreateAccessPointRequest.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/CreateAccessPointRequest.cs
@@ -1,4 +1,5 @@
 using Ryujinx.HLE.HOS.Services.Ldn.Types;
+using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Types;
 using System.Runtime.InteropServices;
 
 namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types
@@ -6,11 +7,13 @@ namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types
     /// <remarks>
     /// Advertise data is appended separately (remaining data in the buffer).
     /// </remarks>
-    [StructLayout(LayoutKind.Sequential, Size = 0x94, CharSet = CharSet.Ansi)]
+    [StructLayout(LayoutKind.Sequential, Size = 0xBC, Pack = 1)]
     struct CreateAccessPointRequest
     {
         public SecurityConfig SecurityConfig;
         public UserConfig UserConfig;
         public NetworkConfig NetworkConfig;
+        
+        public RyuNetworkConfig RyuNetworkConfig;
     }
 }

--- a/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/ProxyConfig.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ldn/UserServiceCreator/Types/ProxyConfig.cs
@@ -1,0 +1,11 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.Types
+{
+    [StructLayout(LayoutKind.Sequential, Size = 0x8)]
+    struct ProxyConfig
+    {
+        public uint ProxyIp;
+        public uint ProxySubnetMask;
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/IClient.cs
@@ -95,7 +95,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd
                 }
             }
 
-            ISocket newBsdSocket = new ManagedSocket(netDomain, (SocketType)type, protocol)
+            ISocket newBsdSocket = new ManagedSocket(netDomain, (SocketType)type, protocol, context.Device.Configuration.MultiplayerLanInterfaceId)
             {
                 Blocking = !creationFlags.HasFlag(BsdSocketCreationFlags.NonBlocking),
             };

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocketPollManager.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Impl/ManagedSocketPollManager.cs
@@ -1,4 +1,5 @@
 using Ryujinx.Common.Logging;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy;
 using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Types;
 using System.Collections.Generic;
 using System.Net.Sockets;
@@ -26,45 +27,47 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
 
         public LinuxError Poll(List<PollEvent> events, int timeoutMilliseconds, out int updatedCount)
         {
-            List<Socket> readEvents = new();
-            List<Socket> writeEvents = new();
-            List<Socket> errorEvents = new();
+            List<ISocketImpl> readEvents = new();
+            List<ISocketImpl> writeEvents = new();
+            List<ISocketImpl> errorEvents = new();
 
             updatedCount = 0;
 
             foreach (PollEvent evnt in events)
             {
-                ManagedSocket socket = (ManagedSocket)evnt.FileDescriptor;
-
-                bool isValidEvent = evnt.Data.InputEvents == 0;
-
-                errorEvents.Add(socket.Socket);
-
-                if ((evnt.Data.InputEvents & PollEventTypeMask.Input) != 0)
+                if (evnt.FileDescriptor is ManagedSocket ms)
                 {
-                    readEvents.Add(socket.Socket);
+                    bool isValidEvent = evnt.Data.InputEvents == 0;
 
-                    isValidEvent = true;
-                }
+                    errorEvents.Add(ms.Socket);
 
-                if ((evnt.Data.InputEvents & PollEventTypeMask.UrgentInput) != 0)
-                {
-                    readEvents.Add(socket.Socket);
+                    if ((evnt.Data.InputEvents & PollEventTypeMask.Input) != 0)
+                    {
+                        readEvents.Add(ms.Socket);
 
-                    isValidEvent = true;
-                }
+                        isValidEvent = true;
+                    }
 
-                if ((evnt.Data.InputEvents & PollEventTypeMask.Output) != 0)
-                {
-                    writeEvents.Add(socket.Socket);
+                    if ((evnt.Data.InputEvents & PollEventTypeMask.UrgentInput) != 0)
+                    {
+                        readEvents.Add(ms.Socket);
 
-                    isValidEvent = true;
-                }
+                        isValidEvent = true;
+                    }
 
-                if (!isValidEvent)
-                {
-                    Logger.Warning?.Print(LogClass.ServiceBsd, $"Unsupported Poll input event type: {evnt.Data.InputEvents}");
-                    return LinuxError.EINVAL;
+                    if ((evnt.Data.InputEvents & PollEventTypeMask.Output) != 0)
+                    {
+                        writeEvents.Add(ms.Socket);
+
+                        isValidEvent = true;
+                    }
+
+                    if (!isValidEvent)
+                    {
+                        Logger.Warning?.Print(LogClass.ServiceBsd,
+                            $"Unsupported Poll input event type: {evnt.Data.InputEvents}");
+                        return LinuxError.EINVAL;
+                    }
                 }
             }
 
@@ -72,7 +75,7 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
             {
                 int actualTimeoutMicroseconds = timeoutMilliseconds == -1 ? -1 : timeoutMilliseconds * 1000;
 
-                Socket.Select(readEvents, writeEvents, errorEvents, actualTimeoutMicroseconds);
+                SocketHelpers.Select(readEvents, writeEvents, errorEvents, actualTimeoutMicroseconds);
             }
             catch (SocketException exception)
             {
@@ -81,34 +84,37 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
 
             foreach (PollEvent evnt in events)
             {
-                Socket socket = ((ManagedSocket)evnt.FileDescriptor).Socket;
-
-                PollEventTypeMask outputEvents = evnt.Data.OutputEvents & ~evnt.Data.InputEvents;
-
-                if (errorEvents.Contains(socket))
+                if (evnt.FileDescriptor is ManagedSocket ms)
                 {
-                    outputEvents |= PollEventTypeMask.Error;
+                    ISocketImpl socket = ms.Socket;
 
-                    if (!socket.Connected || !socket.IsBound)
+                    PollEventTypeMask outputEvents = evnt.Data.OutputEvents & ~evnt.Data.InputEvents;
+
+                    if (errorEvents.Contains(ms.Socket))
                     {
-                        outputEvents |= PollEventTypeMask.Disconnected;
-                    }
-                }
+                        outputEvents |= PollEventTypeMask.Error;
 
-                if (readEvents.Contains(socket))
-                {
-                    if ((evnt.Data.InputEvents & PollEventTypeMask.Input) != 0)
+                        if (!socket.Connected || !socket.IsBound)
+                        {
+                            outputEvents |= PollEventTypeMask.Disconnected;
+                        }
+                    }
+
+                    if (readEvents.Contains(ms.Socket))
                     {
-                        outputEvents |= PollEventTypeMask.Input;
+                        if ((evnt.Data.InputEvents & PollEventTypeMask.Input) != 0)
+                        {
+                            outputEvents |= PollEventTypeMask.Input;
+                        }
                     }
-                }
 
-                if (writeEvents.Contains(socket))
-                {
-                    outputEvents |= PollEventTypeMask.Output;
-                }
+                    if (writeEvents.Contains(ms.Socket))
+                    {
+                        outputEvents |= PollEventTypeMask.Output;
+                    }
 
-                evnt.Data.OutputEvents = outputEvents;
+                    evnt.Data.OutputEvents = outputEvents;
+                }
             }
 
             updatedCount = readEvents.Count + writeEvents.Count + errorEvents.Count;
@@ -118,53 +124,55 @@ namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl
 
         public LinuxError Select(List<PollEvent> events, int timeout, out int updatedCount)
         {
-            List<Socket> readEvents = new();
-            List<Socket> writeEvents = new();
-            List<Socket> errorEvents = new();
+            List<ISocketImpl> readEvents = new();
+            List<ISocketImpl> writeEvents = new();
+            List<ISocketImpl> errorEvents = new();
 
             updatedCount = 0;
 
             foreach (PollEvent pollEvent in events)
             {
-                ManagedSocket socket = (ManagedSocket)pollEvent.FileDescriptor;
-
-                if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Input))
+                if (pollEvent.FileDescriptor is ManagedSocket ms)
                 {
-                    readEvents.Add(socket.Socket);
-                }
+                    if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Input))
+                    {
+                        readEvents.Add(ms.Socket);
+                    }
 
-                if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Output))
-                {
-                    writeEvents.Add(socket.Socket);
-                }
+                    if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Output))
+                    {
+                        writeEvents.Add(ms.Socket);
+                    }
 
-                if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Error))
-                {
-                    errorEvents.Add(socket.Socket);
+                    if (pollEvent.Data.InputEvents.HasFlag(PollEventTypeMask.Error))
+                    {
+                        errorEvents.Add(ms.Socket);
+                    }
                 }
             }
 
-            Socket.Select(readEvents, writeEvents, errorEvents, timeout);
+            SocketHelpers.Select(readEvents, writeEvents, errorEvents, timeout);
 
             updatedCount = readEvents.Count + writeEvents.Count + errorEvents.Count;
 
             foreach (PollEvent pollEvent in events)
             {
-                ManagedSocket socket = (ManagedSocket)pollEvent.FileDescriptor;
-
-                if (readEvents.Contains(socket.Socket))
+                if (pollEvent.FileDescriptor is ManagedSocket ms)
                 {
-                    pollEvent.Data.OutputEvents |= PollEventTypeMask.Input;
-                }
+                    if (readEvents.Contains(ms.Socket))
+                    {
+                        pollEvent.Data.OutputEvents |= PollEventTypeMask.Input;
+                    }
 
-                if (writeEvents.Contains(socket.Socket))
-                {
-                    pollEvent.Data.OutputEvents |= PollEventTypeMask.Output;
-                }
+                    if (writeEvents.Contains(ms.Socket))
+                    {
+                        pollEvent.Data.OutputEvents |= PollEventTypeMask.Output;
+                    }
 
-                if (errorEvents.Contains(socket.Socket))
-                {
-                    pollEvent.Data.OutputEvents |= PollEventTypeMask.Error;
+                    if (errorEvents.Contains(ms.Socket))
+                    {
+                        pollEvent.Data.OutputEvents |= PollEventTypeMask.Error;
+                    }
                 }
             }
 

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/DefaultSocket.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/DefaultSocket.cs
@@ -1,0 +1,178 @@
+﻿using Ryujinx.Common.Utilities;
+using System;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Net.Sockets;
+
+namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy
+{
+    class DefaultSocket : ISocketImpl
+    {
+        public Socket BaseSocket { get; }
+
+        public EndPoint RemoteEndPoint => BaseSocket.RemoteEndPoint;
+
+        public EndPoint LocalEndPoint => BaseSocket.LocalEndPoint;
+
+        public bool Connected => BaseSocket.Connected;
+
+        public bool IsBound => BaseSocket.IsBound;
+
+        public AddressFamily AddressFamily => BaseSocket.AddressFamily;
+
+        public SocketType SocketType => BaseSocket.SocketType;
+
+        public ProtocolType ProtocolType => BaseSocket.ProtocolType;
+
+        public bool Blocking { get => BaseSocket.Blocking; set => BaseSocket.Blocking = value; }
+
+        public int Available => BaseSocket.Available;
+
+        private readonly string _lanInterfaceId;
+
+        public DefaultSocket(Socket baseSocket, string lanInterfaceId)
+        {
+            _lanInterfaceId = lanInterfaceId;
+
+            BaseSocket = baseSocket;
+        }
+
+        public DefaultSocket(AddressFamily domain, SocketType type, ProtocolType protocol, string lanInterfaceId)
+        {
+            _lanInterfaceId = lanInterfaceId;
+
+            BaseSocket = new Socket(domain, type, protocol);
+        }
+
+        private void EnsureNetworkInterfaceBound()
+        {
+            if (_lanInterfaceId != "0" && !BaseSocket.IsBound)
+            {
+                (_, UnicastIPAddressInformation ipInfo) = NetworkHelpers.GetLocalInterface(_lanInterfaceId);
+
+                BaseSocket.Bind(new IPEndPoint(ipInfo.Address, 0));
+            }
+        }
+
+        public ISocketImpl Accept()
+        {
+            return new DefaultSocket(BaseSocket.Accept(), _lanInterfaceId);
+        }
+
+        public void Bind(EndPoint localEP)
+        {
+            // NOTE: The guest is able to receive on 0.0.0.0 without it being limited to the chosen network interface.
+            // This is because it must get loopback traffic as well. This could allow other network traffic to leak in.
+
+            BaseSocket.Bind(localEP);
+        }
+
+        public void Close()
+        {
+            BaseSocket.Close();
+        }
+
+        public void Connect(EndPoint remoteEP)
+        {
+            EnsureNetworkInterfaceBound();
+
+            BaseSocket.Connect(remoteEP);
+        }
+
+        public void Disconnect(bool reuseSocket)
+        {
+            BaseSocket.Disconnect(reuseSocket);
+        }
+
+        public void GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue)
+        {
+            BaseSocket.GetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        public void Listen(int backlog)
+        {
+            BaseSocket.Listen(backlog);
+        }
+
+        public int Receive(Span<byte> buffer)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Receive(buffer);
+        }
+
+        public int Receive(Span<byte> buffer, SocketFlags flags)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Receive(buffer, flags);
+        }
+
+        public int Receive(Span<byte> buffer, SocketFlags flags, out SocketError socketError)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Receive(buffer, flags, out socketError);
+        }
+
+        public int ReceiveFrom(Span<byte> buffer, SocketFlags flags, ref EndPoint remoteEP)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.ReceiveFrom(buffer, flags, ref remoteEP);
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Send(buffer);
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer, SocketFlags flags)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Send(buffer, flags);
+        }
+
+        public int Send(ReadOnlySpan<byte> buffer, SocketFlags flags, out SocketError socketError)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.Send(buffer, flags, out socketError);
+        }
+
+        public int SendTo(ReadOnlySpan<byte> buffer, SocketFlags flags, EndPoint remoteEP)
+        {
+            EnsureNetworkInterfaceBound();
+
+            return BaseSocket.SendTo(buffer, flags, remoteEP);
+        }
+
+        public bool Poll(int microSeconds, SelectMode mode)
+        {
+            return BaseSocket.Poll(microSeconds, mode);
+        }
+
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue)
+        {
+            BaseSocket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        public void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue)
+        {
+            BaseSocket.SetSocketOption(optionLevel, optionName, optionValue);
+        }
+
+        public void Shutdown(SocketShutdown how)
+        {
+            BaseSocket.Shutdown(how);
+        }
+
+        public void Dispose()
+        {
+            BaseSocket.Dispose();
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/ISocket.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/ISocket.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy
+{
+    interface ISocketImpl : IDisposable
+    {
+        EndPoint RemoteEndPoint { get; }
+        EndPoint LocalEndPoint { get; }
+        bool Connected { get; }
+        bool IsBound { get; }
+        AddressFamily AddressFamily { get; }
+        SocketType SocketType { get; }
+        ProtocolType ProtocolType { get; }
+        bool Blocking { get; set; }
+        int Available { get; }
+        int Receive(Span<byte> buffer);
+        int Receive(Span<byte> buffer, SocketFlags flags);
+        int Receive(Span<byte> buffer, SocketFlags flags, out SocketError socketError);
+        int ReceiveFrom(Span<byte> buffer, SocketFlags flags, ref EndPoint remoteEP);
+        int Send(ReadOnlySpan<byte> buffer);
+        int Send(ReadOnlySpan<byte> buffer, SocketFlags flags);
+        int Send(ReadOnlySpan<byte> buffer, SocketFlags flags, out SocketError socketError);
+        int SendTo(ReadOnlySpan<byte> buffer, SocketFlags flags, EndPoint remoteEP);
+        bool Poll(int microSeconds, SelectMode mode);
+        ISocketImpl Accept();
+        void Bind(EndPoint localEP);
+        void Connect(EndPoint remoteEP);
+        void Listen(int backlog);
+        void GetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, byte[] optionValue);
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue);
+        void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, object optionValue);
+        void Shutdown(SocketShutdown how);
+        void Disconnect(bool reuseSocket);
+        void Close();
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/SocketHelpers.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Sockets/Bsd/Proxy/SocketHelpers.cs
@@ -1,0 +1,79 @@
+﻿using Ryujinx.HLE.HOS.Services.Ldn.UserServiceCreator.LdnRyu.Proxy;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Sockets;
+
+namespace Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy
+{
+    static class SocketHelpers
+    {
+        private static LdnProxy _proxy;
+
+        public static void Select(List<ISocketImpl> readEvents, List<ISocketImpl> writeEvents,
+            List<ISocketImpl> errorEvents, int timeout)
+        {
+            var readDefault = readEvents.Select(x => (x as DefaultSocket)?.BaseSocket).Where(x => x != null).ToList();
+            var writeDefault = writeEvents.Select(x => (x as DefaultSocket)?.BaseSocket).Where(x => x != null).ToList();
+            var errorDefault = errorEvents.Select(x => (x as DefaultSocket)?.BaseSocket).Where(x => x != null).ToList();
+
+            if (readDefault.Count != 0 || writeDefault.Count != 0 || errorDefault.Count != 0)
+            {
+                Socket.Select(readDefault, writeDefault, errorDefault, timeout);
+            }
+
+            void FilterSockets(List<ISocketImpl> removeFrom, List<Socket> selectedSockets,
+                Func<LdnProxySocket, bool> ldnCheck)
+            {
+                removeFrom.RemoveAll(socket =>
+                {
+                    switch (socket)
+                    {
+                        case DefaultSocket dsocket:
+                            return !selectedSockets.Contains(dsocket.BaseSocket);
+                        case LdnProxySocket psocket:
+                            return !ldnCheck(psocket);
+                        default:
+                            throw new NotImplementedException();
+                    }
+                });
+            }
+
+            ;
+
+            FilterSockets(readEvents, readDefault, (socket) => socket.Readable);
+            FilterSockets(writeEvents, writeDefault, (socket) => socket.Writable);
+            FilterSockets(errorEvents, errorDefault, (socket) => socket.Error);
+        }
+
+        public static void RegisterProxy(LdnProxy proxy)
+        {
+            if (_proxy != null)
+            {
+                UnregisterProxy();
+            }
+
+            _proxy = proxy;
+        }
+
+        public static void UnregisterProxy()
+        {
+            _proxy?.Dispose();
+            _proxy = null;
+        }
+
+        public static ISocketImpl CreateSocket(AddressFamily domain, SocketType type, ProtocolType protocol,
+            string lanInterfaceId)
+        {
+            if (_proxy != null)
+            {
+                if (_proxy.Supported(domain, type, protocol))
+                {
+                    return new LdnProxySocket(domain, type, protocol, _proxy);
+                }
+            }
+
+            return new DefaultSocket(domain, type, protocol, lanInterfaceId);
+        }
+    }
+}

--- a/src/Ryujinx.HLE/HOS/Services/Ssl/SslService/SslManagedSocketConnection.cs
+++ b/src/Ryujinx.HLE/HOS/Services/Ssl/SslService/SslManagedSocketConnection.cs
@@ -1,5 +1,6 @@
 using Ryujinx.HLE.HOS.Services.Sockets.Bsd;
 using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Impl;
+using Ryujinx.HLE.HOS.Services.Sockets.Bsd.Proxy;
 using Ryujinx.HLE.HOS.Services.Ssl.Types;
 using System;
 using System.IO;
@@ -116,7 +117,9 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
         public ResultCode Handshake(string hostName)
         {
             StartSslOperation();
-            _stream = new SslStream(new NetworkStream(((ManagedSocket)Socket).Socket, false), false, null, null);
+            _stream = new SslStream(
+                new NetworkStream(((DefaultSocket)((ManagedSocket)Socket).Socket).BaseSocket, false), false, null,
+                null);
             hostName = RetrieveHostName(hostName);
             _stream.AuthenticateAsClient(hostName, null, TranslateSslVersion(_sslVersion), false);
             EndSslOperation();
@@ -251,7 +254,8 @@ namespace Ryujinx.HLE.HOS.Services.Ssl.SslService
             return ResultCode.Success;
         }
 
-        public ResultCode GetServerCertificate(string hostname, Span<byte> certificates, out uint storageSize, out uint certificateCount)
+        public ResultCode GetServerCertificate(string hostname, Span<byte> certificates, out uint storageSize,
+            out uint certificateCount)
         {
             byte[] rawCertData = _stream.RemoteCertificate.GetRawCertData();
 

--- a/src/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
+++ b/src/Ryujinx.HLE/Loaders/Processes/ProcessResult.cs
@@ -12,7 +12,8 @@ namespace Ryujinx.HLE.Loaders.Processes
 {
     public class ProcessResult
     {
-        public static ProcessResult Failed => new(null, new BlitStruct<ApplicationControlProperty>(1), false, false, null, 0, 0, 0, TitleLanguage.AmericanEnglish);
+        public static ProcessResult Failed => new(null, new BlitStruct<ApplicationControlProperty>(1), false, false,
+            null, 0, 0, 0, TitleLanguage.AmericanEnglish);
 
         private readonly byte _mainThreadPriority;
         private readonly uint _mainThreadStackSize;
@@ -59,7 +60,8 @@ namespace Ryujinx.HLE.Loaders.Processes
 
                 if (string.IsNullOrWhiteSpace(Name))
                 {
-                    Name = Array.Find(ApplicationControlProperties.Title.ItemsRo.ToArray(), x => x.Name[0] != 0).NameString.ToString();
+                    Name = Array.Find(ApplicationControlProperties.Title.ItemsRo.ToArray(), x => x.Name[0] != 0)
+                        .NameString.ToString();
                 }
 
                 DisplayVersion = ApplicationControlProperties.DisplayVersionString.ToString();
@@ -76,7 +78,8 @@ namespace Ryujinx.HLE.Loaders.Processes
         {
             device.Configuration.ContentManager.LoadEntries(device);
 
-            Result result = device.System.KernelContext.Processes[ProcessId].Start(_mainThreadPriority, _mainThreadStackSize);
+            Result result = device.System.KernelContext.Processes[ProcessId]
+                .Start(_mainThreadPriority, _mainThreadStackSize);
             if (result != Result.Success)
             {
                 Logger.Error?.Print(LogClass.Loader, $"Process start returned error \"{result}\".");
@@ -85,11 +88,12 @@ namespace Ryujinx.HLE.Loaders.Processes
             }
 
             // TODO: LibHac npdm currently doesn't support version field.
-            string version = ProgramId > 0x0100000000007FFF 
-                ? DisplayVersion 
+            string version = ProgramId > 0x0100000000007FFF
+                ? DisplayVersion
                 : device.System.ContentManager.GetCurrentFirmwareVersion()?.VersionString ?? "?";
 
-            Logger.Info?.Print(LogClass.Loader, $"Application Loaded: {Name} v{version} [{ProgramIdText}] [{(Is64Bit ? "64-bit" : "32-bit")}]");
+            Logger.Info?.Print(LogClass.Loader,
+                $"Application Loaded: {Name} v{version} [{ProgramIdText}] [{(Is64Bit ? "64-bit" : "32-bit")}]");
 
             return true;
         }

--- a/src/Ryujinx.HLE/Ryujinx.HLE.csproj
+++ b/src/Ryujinx.HLE/Ryujinx.HLE.csproj
@@ -6,47 +6,48 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
-    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj" />
-    <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj" />
-    <ProjectReference Include="..\Ryujinx.Graphics.Host1x\Ryujinx.Graphics.Host1x.csproj" />
-    <ProjectReference Include="..\Ryujinx.Graphics.Nvdec\Ryujinx.Graphics.Nvdec.csproj" />
-    <ProjectReference Include="..\Ryujinx.Graphics.Vic\Ryujinx.Graphics.Vic.csproj" />
+    <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Common\Ryujinx.Common.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Graphics.Host1x\Ryujinx.Graphics.Host1x.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Graphics.Nvdec\Ryujinx.Graphics.Nvdec.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Graphics.Vic\Ryujinx.Graphics.Vic.csproj"/>
     <ProjectReference Include="..\Ryujinx.HLE.Generators\Ryujinx.HLE.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
-    <ProjectReference Include="..\Ryujinx.Horizon.Common\Ryujinx.Horizon.Common.csproj" />
-    <ProjectReference Include="..\Ryujinx.Horizon.Kernel.Generators\Ryujinx.Horizon.Kernel.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\Ryujinx.Horizon\Ryujinx.Horizon.csproj" />
-    <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
-    <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj" />
-    <ProjectReference Include="..\Ryujinx.Graphics.Gpu\Ryujinx.Graphics.Gpu.csproj" />
-    <ProjectReference Include="..\Ryujinx.Graphics.GAL\Ryujinx.Graphics.GAL.csproj" />
+    <ProjectReference Include="..\Ryujinx.Horizon.Common\Ryujinx.Horizon.Common.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Horizon.Kernel.Generators\Ryujinx.Horizon.Kernel.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\Ryujinx.Horizon\Ryujinx.Horizon.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj"/>
+    <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Graphics.Gpu\Ryujinx.Graphics.Gpu.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Graphics.GAL\Ryujinx.Graphics.GAL.csproj"/>
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LibHac" />
-    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" />
-    <PackageReference Include="MsgPack.Cli" />
-    <PackageReference Include="SkiaSharp" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
-    <PackageReference Include="NetCoreServer" />
+    <PackageReference Include="LibHac"/>
+    <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens"/>
+    <PackageReference Include="MsgPack.Cli"/>
+    <PackageReference Include="SkiaSharp"/>
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux"/>
+    <PackageReference Include="NetCoreServer"/>
+    <PackageReference Include="Open.NAT.Core"/>
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Homebrew.npdm" />
-    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Logo_Ryujinx.png" />
-    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnA.png" />
-    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnB.png" />
-    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_KeyF6.png" />
-    <None Remove="HOS\Services\Account\Acc\DefaultUserImage.jpg" />
+    <None Remove="Homebrew.npdm"/>
+    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Logo_Ryujinx.png"/>
+    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnA.png"/>
+    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnB.png"/>
+    <None Remove="HOS\Applets\SoftwareKeyboard\Resources\Icon_KeyF6.png"/>
+    <None Remove="HOS\Services\Account\Acc\DefaultUserImage.jpg"/>
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Include="Homebrew.npdm" />
-    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Logo_Ryujinx.png" />
-    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnA.png" />
-    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnB.png" />
-    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_KeyF6.png" />
-    <EmbeddedResource Include="HOS\Services\Account\Acc\DefaultUserImage.jpg" />
+    <EmbeddedResource Include="Homebrew.npdm"/>
+    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Logo_Ryujinx.png"/>
+    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnA.png"/>
+    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_BtnB.png"/>
+    <EmbeddedResource Include="HOS\Applets\SoftwareKeyboard\Resources\Icon_KeyF6.png"/>
+    <EmbeddedResource Include="HOS\Services\Account\Acc\DefaultUserImage.jpg"/>
   </ItemGroup>
 
 </Project>

--- a/src/Ryujinx.Headless.SDL2/Program.cs
+++ b/src/Ryujinx.Headless.SDL2/Program.cs
@@ -59,7 +59,8 @@ namespace Ryujinx.Headless.SDL2
         private static bool _enableKeyboard;
         private static bool _enableMouse;
 
-        private static readonly InputConfigJsonSerializerContext _serializerContext = new(JsonHelper.GetDefaultSerializerOptions());
+        private static readonly InputConfigJsonSerializerContext _serializerContext =
+            new(JsonHelper.GetDefaultSerializerOptions());
 
         static void Main(string[] args)
         {
@@ -96,8 +97,8 @@ namespace Ryujinx.Headless.SDL2
             }
 
             Parser.Default.ParseArguments<Options>(args)
-            .WithParsed(Load)
-            .WithNotParsed(errors => errors.Output());
+                .WithParsed(Load)
+                .WithNotParsed(errors => errors.Output());
         }
 
         private static InputConfig HandlePlayerConfiguration(string inputProfileName, string inputId, PlayerIndex index)
@@ -106,7 +107,8 @@ namespace Ryujinx.Headless.SDL2
             {
                 if (index == PlayerIndex.Player1)
                 {
-                    Logger.Info?.Print(LogClass.Application, $"{index} not configured, defaulting to default keyboard.");
+                    Logger.Info?.Print(LogClass.Application,
+                        $"{index} not configured, defaulting to default keyboard.");
 
                     // Default to keyboard
                     inputId = "0";
@@ -164,7 +166,6 @@ namespace Ryujinx.Headless.SDL2
                             ButtonSl = Key.Unbound,
                             ButtonSr = Key.Unbound,
                         },
-
                         LeftJoyconStick = new JoyconConfigKeyboardStick<Key>
                         {
                             StickUp = Key.W,
@@ -173,7 +174,6 @@ namespace Ryujinx.Headless.SDL2
                             StickRight = Key.D,
                             StickButton = Key.F,
                         },
-
                         RightJoycon = new RightJoyconCommonConfig<Key>
                         {
                             ButtonA = Key.Z,
@@ -186,7 +186,6 @@ namespace Ryujinx.Headless.SDL2
                             ButtonSl = Key.Unbound,
                             ButtonSr = Key.Unbound,
                         },
-
                         RightJoyconStick = new JoyconConfigKeyboardStick<Key>
                         {
                             StickUp = Key.I,
@@ -224,7 +223,6 @@ namespace Ryujinx.Headless.SDL2
                             ButtonSl = ConfigGamepadInputId.Unbound,
                             ButtonSr = ConfigGamepadInputId.Unbound,
                         },
-
                         LeftJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>
                         {
                             Joystick = ConfigStickInputId.Left,
@@ -233,7 +231,6 @@ namespace Ryujinx.Headless.SDL2
                             InvertStickY = false,
                             Rotate90CW = false,
                         },
-
                         RightJoycon = new RightJoyconCommonConfig<ConfigGamepadInputId>
                         {
                             ButtonA = isNintendoStyle ? ConfigGamepadInputId.A : ConfigGamepadInputId.B,
@@ -246,7 +243,6 @@ namespace Ryujinx.Headless.SDL2
                             ButtonSl = ConfigGamepadInputId.Unbound,
                             ButtonSr = ConfigGamepadInputId.Unbound,
                         },
-
                         RightJoyconStick = new JoyconConfigControllerStick<ConfigGamepadInputId, ConfigStickInputId>
                         {
                             Joystick = ConfigStickInputId.Right,
@@ -255,7 +251,6 @@ namespace Ryujinx.Headless.SDL2
                             InvertStickY = false,
                             Rotate90CW = false,
                         },
-
                         Motion = new StandardMotionConfigController
                         {
                             MotionBackend = MotionInputBackendType.GamepadDriver,
@@ -265,9 +260,7 @@ namespace Ryujinx.Headless.SDL2
                         },
                         Rumble = new RumbleConfigController
                         {
-                            StrongRumble = 1f,
-                            WeakRumble = 1f,
-                            EnableRumble = false,
+                            StrongRumble = 1f, WeakRumble = 1f, EnableRumble = false,
                         },
                     };
                 }
@@ -289,7 +282,8 @@ namespace Ryujinx.Headless.SDL2
 
                 if (!File.Exists(path))
                 {
-                    Logger.Error?.Print(LogClass.Application, $"Input profile \"{inputProfileName}\" not found for \"{inputId}\"");
+                    Logger.Error?.Print(LogClass.Application,
+                        $"Input profile \"{inputProfileName}\" not found for \"{inputId}\"");
 
                     return null;
                 }
@@ -300,7 +294,8 @@ namespace Ryujinx.Headless.SDL2
                 }
                 catch (JsonException)
                 {
-                    Logger.Error?.Print(LogClass.Application, $"Input profile \"{inputProfileName}\" parsing failed for \"{inputId}\"");
+                    Logger.Error?.Print(LogClass.Application,
+                        $"Input profile \"{inputProfileName}\" parsing failed for \"{inputId}\"");
 
                     return null;
                 }
@@ -311,7 +306,8 @@ namespace Ryujinx.Headless.SDL2
 
             string inputTypeName = isKeyboard ? "Keyboard" : "Gamepad";
 
-            Logger.Info?.Print(LogClass.Application, $"{config.PlayerIndex} configured with {inputTypeName} \"{config.Id}\"");
+            Logger.Info?.Print(LogClass.Application,
+                $"{config.PlayerIndex} configured with {inputTypeName} \"{config.Id}\"");
 
             // If both stick ranges are 0 (usually indicative of an outdated profile load) then both sticks will be set to 1.0.
             if (config is StandardControllerInputConfig controllerConfig)
@@ -321,7 +317,8 @@ namespace Ryujinx.Headless.SDL2
                     controllerConfig.RangeLeft = 1.0f;
                     controllerConfig.RangeRight = 1.0f;
 
-                    Logger.Info?.Print(LogClass.Application, $"{config.PlayerIndex} stick range reset. Save the profile now to update your configuration");
+                    Logger.Info?.Print(LogClass.Application,
+                        $"{config.PlayerIndex} stick range reset. Save the profile now to update your configuration");
                 }
             }
 
@@ -353,7 +350,8 @@ namespace Ryujinx.Headless.SDL2
                 if (option.GraphicsBackend == GraphicsBackend.OpenGl)
                 {
                     option.GraphicsBackend = GraphicsBackend.Vulkan;
-                    Logger.Warning?.Print(LogClass.Application, "OpenGL is not supported on macOS, switching to Vulkan!");
+                    Logger.Warning?.Print(LogClass.Application,
+                        "OpenGL is not supported on macOS, switching to Vulkan!");
                 }
             }
 
@@ -449,7 +447,8 @@ namespace Ryujinx.Headless.SDL2
                 }
                 else
                 {
-                    Logger.Error?.Print(LogClass.Application, "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
+                    Logger.Error?.Print(LogClass.Application,
+                        "No writable log directory available. Make sure either the Logs directory, Application Data, or the Ryujinx directory is writable.");
                 }
             }
 
@@ -505,8 +504,10 @@ namespace Ryujinx.Headless.SDL2
         private static WindowBase CreateWindow(Options options)
         {
             return options.GraphicsBackend == GraphicsBackend.Vulkan
-                ? new VulkanWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet)
-                : new OpenGLWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio, options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet);
+                ? new VulkanWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio,
+                    options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet)
+                : new OpenGLWindow(_inputManager, options.LoggingGraphicsDebugLevel, options.AspectRatio,
+                    options.EnableMouse, options.HideCursorMode, options.IgnoreControllerApplet);
         }
 
         private static IRenderer CreateRenderer(Options options, WindowBase window)
@@ -545,7 +546,8 @@ namespace Ryujinx.Headless.SDL2
         {
             BackendThreading threadingMode = options.BackendThreading;
 
-            bool threadedGAL = threadingMode == BackendThreading.On || (threadingMode == BackendThreading.Auto && renderer.PreferThreading);
+            bool threadedGAL = threadingMode == BackendThreading.On ||
+                               (threadingMode == BackendThreading.Auto && renderer.PreferThreading);
 
             if (threadedGAL)
             {
@@ -577,7 +579,10 @@ namespace Ryujinx.Headless.SDL2
                 options.AudioVolume,
                 options.UseHypervisor ?? true,
                 options.MultiplayerLanInterfaceId,
-                Common.Configuration.Multiplayer.MultiplayerMode.Disabled);
+                Common.Configuration.Multiplayer.MultiplayerMode.Disabled,
+                false,
+                "",
+                "");
 
             return new Switch(configuration);
         }
@@ -676,6 +681,7 @@ namespace Ryujinx.Headless.SDL2
 
                             return false;
                         }
+
                         break;
                     case ".nca":
                         Logger.Info?.Print(LogClass.Application, "Loading as NCA.");
@@ -686,6 +692,7 @@ namespace Ryujinx.Headless.SDL2
 
                             return false;
                         }
+
                         break;
                     case ".nsp":
                     case ".pfs0":
@@ -697,6 +704,7 @@ namespace Ryujinx.Headless.SDL2
 
                             return false;
                         }
+
                         break;
                     default:
                         Logger.Info?.Print(LogClass.Application, "Loading as Homebrew.");
@@ -711,18 +719,21 @@ namespace Ryujinx.Headless.SDL2
                         }
                         catch (ArgumentOutOfRangeException)
                         {
-                            Logger.Error?.Print(LogClass.Application, "The specified file is not supported by Ryujinx.");
+                            Logger.Error?.Print(LogClass.Application,
+                                "The specified file is not supported by Ryujinx.");
 
                             _emulationContext.Dispose();
 
                             return false;
                         }
+
                         break;
                 }
             }
             else
             {
-                Logger.Warning?.Print(LogClass.Application, $"Couldn't load '{options.InputPath}'. Please specify a valid XCI/NCA/NSP/PFS0/NRO file.");
+                Logger.Warning?.Print(LogClass.Application,
+                    $"Couldn't load '{options.InputPath}'. Please specify a valid XCI/NCA/NSP/PFS0/NRO file.");
 
                 _emulationContext.Dispose();
 

--- a/src/Ryujinx.Memory/Tracking/RegionHandle.cs
+++ b/src/Ryujinx.Memory/Tracking/RegionHandle.cs
@@ -389,9 +389,9 @@ namespace Ryujinx.Memory.Tracking
         }
 
         /// <summary>
-        /// Consume the dirty flag for this handle, and reprotect so it can be set on the next write.
+        /// Consume the dirty flag for this handle, and protect so it can be set on the next write.
         /// </summary>
-        /// <param name="asDirty">True if the handle should be reprotected as dirty, rather than have it cleared</param>
+        /// <param name="asDirty">True if the handle should be protected as dirty, rather than have it cleared</param>
         public void Reprotect(bool asDirty = false)
         {
             Reprotect(asDirty, false);

--- a/src/Ryujinx.Tests.Memory/MultiRegionTrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/MultiRegionTrackingTests.cs
@@ -56,8 +56,8 @@ namespace Ryujinx.Tests.Memory
 
             handle.QueryModified(startAddress, size, (address, range) =>
             {
-                Assert.IsTrue(addressPredicate(address)); // Written pages must be even.
-                Assert.GreaterOrEqual(address, lastAddress); // Must be signalled in ascending order, regardless of write order.
+                Assert.That(addressPredicate(address), Is.True); // Written pages must be even.
+                Assert.That(address, Is.GreaterThanOrEqualTo(lastAddress)); // Must be signalled in ascending order, regardless of write order.
                 lastAddress = address;
                 regionCount++;
             });
@@ -72,8 +72,8 @@ namespace Ryujinx.Tests.Memory
 
             handle.QueryModified(startAddress, size, (address, range) =>
             {
-                Assert.IsTrue(addressPredicate(address)); // Written pages must be even.
-                Assert.GreaterOrEqual(address, lastAddress); // Must be signalled in ascending order, regardless of write order.
+                Assert.That(addressPredicate(address), Is.True); // Written pages must be even.
+                Assert.That(address, Is.GreaterThanOrEqualTo(lastAddress)); // Must be signalled in ascending order, regardless of write order.
                 lastAddress = address;
                 regionCount++;
             }, sequenceNumber);
@@ -93,7 +93,7 @@ namespace Ryujinx.Tests.Memory
                 {
                     resultAddress = address;
                 });
-                Assert.AreEqual(resultAddress, (ulong)i * PageSize + address);
+                Assert.That(resultAddress, Is.EqualTo((ulong)i * PageSize + address));
             });
         }
 
@@ -119,7 +119,7 @@ namespace Ryujinx.Tests.Memory
 
             int oddRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 1);
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.That(oddRegionCount, Is.EqualTo(PageCount / 2)); // Must have written to all odd pages.
 
             // Write to all the even pages.
             RandomOrder(random, even, (i) =>
@@ -129,7 +129,7 @@ namespace Ryujinx.Tests.Memory
 
             int evenRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 0);
 
-            Assert.AreEqual(evenRegionCount, PageCount / 2);
+            Assert.That(evenRegionCount, Is.EqualTo(PageCount / 2));
         }
 
         [Test]
@@ -172,7 +172,7 @@ namespace Ryujinx.Tests.Memory
                 }, 1);
             }
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.That(oddRegionCount, Is.EqualTo(PageCount / 2)); // Must have written to all odd pages.
 
             // Write to all pages.
 
@@ -182,19 +182,19 @@ namespace Ryujinx.Tests.Memory
 
             int evenRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 0, 1);
 
-            Assert.AreEqual(evenRegionCount, PageCount / 2); // Must have written to all even pages.
+            Assert.That(evenRegionCount, Is.EqualTo(PageCount / 2)); // Must have written to all even pages.
 
             oddRegionCount = 0;
 
             handle.QueryModified(0, PageSize * PageCount, (address, range) => { oddRegionCount++; }, 1);
 
-            Assert.AreEqual(oddRegionCount, 0); // Sequence number has not changed, so found no dirty subregions.
+            Assert.That(oddRegionCount, Is.EqualTo(0)); // Sequence number has not changed, so found no dirty subregions.
 
-            // With sequence number 2, all all pages should be reported as modified.
+            // With sequence number 2, all pages should be reported as modified.
 
             oddRegionCount = ExpectQueryInOrder(handle, 0, PageSize * PageCount, (address) => (address / PageSize) % 2 == 1, 2);
 
-            Assert.AreEqual(oddRegionCount, PageCount / 2); // Must have written to all odd pages.
+            Assert.That(oddRegionCount, Is.EqualTo(PageCount / 2)); // Must have written to all odd pages.
         }
 
         [Test]
@@ -217,7 +217,7 @@ namespace Ryujinx.Tests.Memory
                 handle.QueryModified(address, (ulong)(PageSize * region), (address, size) => { });
 
                 // There should be a gap between regions,
-                // So that they don't combine and we can see the full effects.
+                // So that they don't combine, and we can see the full effects.
                 address += (ulong)(PageSize * (region + 1));
             }
 
@@ -242,8 +242,8 @@ namespace Ryujinx.Tests.Memory
             {
                 int region = regionSizes[regionInd++];
 
-                Assert.AreEqual(address, expectedAddress);
-                Assert.AreEqual(size, (ulong)(PageSize * region));
+                Assert.That(address, Is.EqualTo(expectedAddress));
+                Assert.That(size, Is.EqualTo((ulong)(PageSize * region)));
 
                 expectedAddress += (ulong)(PageSize * (region + 1));
             });
@@ -256,12 +256,12 @@ namespace Ryujinx.Tests.Memory
             const int PageCount = 32;
             const int OverlapStart = 16;
 
-            Assert.AreEqual(0, _tracking.GetRegionCount());
+            Assert.That(0, Is.EqualTo(_tracking.GetRegionCount()));
 
             IMultiRegionHandle handleLow = GetGranular(smart, 0, PageSize * PageCount, PageSize);
             PreparePages(handleLow, PageCount);
 
-            Assert.AreEqual(PageCount, _tracking.GetRegionCount());
+            Assert.That(PageCount, Is.EqualTo(_tracking.GetRegionCount()));
 
             IMultiRegionHandle handleHigh = GetGranular(smart, PageSize * OverlapStart, PageSize * PageCount, PageSize);
             PreparePages(handleHigh, PageCount, PageSize * OverlapStart);
@@ -269,15 +269,15 @@ namespace Ryujinx.Tests.Memory
             // Combined pages (and assuming overlapStart <= pageCount) should be pageCount after overlapStart.
             int totalPages = OverlapStart + PageCount;
 
-            Assert.AreEqual(totalPages, _tracking.GetRegionCount());
+            Assert.That(totalPages, Is.EqualTo(_tracking.GetRegionCount()));
 
             handleLow.Dispose(); // After disposing one, the pages for the other remain.
 
-            Assert.AreEqual(PageCount, _tracking.GetRegionCount());
+            Assert.That(PageCount, Is.EqualTo(_tracking.GetRegionCount()));
 
             handleHigh.Dispose(); // After disposing the other, there are no pages left.
 
-            Assert.AreEqual(0, _tracking.GetRegionCount());
+            Assert.That(0, Is.EqualTo(_tracking.GetRegionCount()));
         }
 
         [Test]
@@ -357,19 +357,19 @@ namespace Ryujinx.Tests.Memory
                 bool modified = false;
                 combined.QueryModified(PageSize * (ulong)i, PageSize, (_, _) => { modified = true; });
 
-                Assert.AreEqual(expectedDirty[i], modified);
+                Assert.That(expectedDirty[i], Is.EqualTo(modified));
             }
 
-            Assert.AreEqual(new bool[3], actionsTriggered);
+            Assert.That(new bool[3], Is.EqualTo(actionsTriggered));
 
             _tracking.VirtualMemoryEvent(PageSize * 5, PageSize, false);
-            Assert.IsTrue(actionsTriggered[0]);
+            Assert.That(actionsTriggered[0], Is.True);
 
             _tracking.VirtualMemoryEvent(PageSize * 10, PageSize, false);
-            Assert.IsTrue(actionsTriggered[1]);
+            Assert.That(actionsTriggered[1], Is.True);
 
             _tracking.VirtualMemoryEvent(PageSize * 15, PageSize, false);
-            Assert.IsTrue(actionsTriggered[2]);
+            Assert.That(actionsTriggered[2], Is.True);
 
             // The double page handles should be disposed, as they were split into granular handles.
             foreach (RegionHandle doublePage in doublePages)
@@ -386,18 +386,18 @@ namespace Ryujinx.Tests.Memory
                     throws = true;
                 }
 
-                Assert.IsTrue(throws);
+                Assert.That(throws, Is.True);
             }
 
             IEnumerable<IRegionHandle> combinedHandles = combined.GetHandles();
 
-            Assert.AreEqual(handleGroups[0].ElementAt(0), combinedHandles.ElementAt(3));
-            Assert.AreEqual(handleGroups[0].ElementAt(1), combinedHandles.ElementAt(4));
-            Assert.AreEqual(handleGroups[0].ElementAt(2), combinedHandles.ElementAt(5));
+            Assert.That(handleGroups[0].ElementAt(0), Is.EqualTo(combinedHandles.ElementAt(3)));
+            Assert.That(handleGroups[0].ElementAt(1), Is.EqualTo(combinedHandles.ElementAt(4)));
+            Assert.That(handleGroups[0].ElementAt(2), Is.EqualTo(combinedHandles.ElementAt(5)));
 
-            Assert.AreEqual(singlePages[0], combinedHandles.ElementAt(8));
-            Assert.AreEqual(singlePages[1], combinedHandles.ElementAt(9));
-            Assert.AreEqual(singlePages[2], combinedHandles.ElementAt(10));
+            Assert.That(singlePages[0], Is.EqualTo(combinedHandles.ElementAt(8)));
+            Assert.That(singlePages[1], Is.EqualTo(combinedHandles.ElementAt(9)));
+            Assert.That(singlePages[2], Is.EqualTo(combinedHandles.ElementAt(10)));
         }
 
         [Test]
@@ -408,18 +408,18 @@ namespace Ryujinx.Tests.Memory
             MultiRegionHandle granular = _tracking.BeginGranularTracking(PageSize * 3, PageSize * 3, null, PageSize, 0);
             PreparePages(granular, 3, PageSize * 3);
 
-            // Add a precise action to the second and third handle in the multiregion.
+            // Add a precise action to the second and third handle in the multi region.
             granular.RegisterPreciseAction(PageSize * 4, PageSize * 2, (_, _, _) => { actionTriggered = true; return true; });
 
-            // Precise write to first handle in the multiregion.
+            // Precise write to first handle in the multi region.
             _tracking.VirtualMemoryEvent(PageSize * 3, PageSize, true, precise: true);
-            Assert.IsFalse(actionTriggered); // Action not triggered.
+            Assert.That(actionTriggered, Is.False); // Action not triggered.
 
             bool firstPageModified = false;
             granular.QueryModified(PageSize * 3, PageSize, (_, _) => { firstPageModified = true; });
-            Assert.IsTrue(firstPageModified); // First page is modified.
+            Assert.That(firstPageModified, Is.True); // First page is modified.
 
-            // Precise write to all handles in the multiregion.
+            // Precise write to all handles in the multi region.
             _tracking.VirtualMemoryEvent(PageSize * 3, PageSize * 3, true, precise: true);
 
             bool[] pagesModified = new bool[3];
@@ -430,10 +430,10 @@ namespace Ryujinx.Tests.Memory
                 granular.QueryModified(PageSize * (ulong)i, PageSize, (_, _) => { pagesModified[index] = true; });
             }
 
-            Assert.IsTrue(actionTriggered); // Action triggered.
+            Assert.That(actionTriggered, Is.True); // Action triggered.
 
             // Precise writes are ignored on two later handles due to the action returning true.
-            Assert.AreEqual(pagesModified, new bool[] { true, false, false });
+            Assert.That(pagesModified, Is.EqualTo(new bool[] { true, false, false }));
         }
     }
 }

--- a/src/Ryujinx.Tests.Memory/Tests.cs
+++ b/src/Ryujinx.Tests.Memory/Tests.cs
@@ -28,7 +28,7 @@ namespace Ryujinx.Tests.Memory
         {
             Marshal.WriteInt32(_memoryBlock.Pointer, 0x2020, 0x1234abcd);
 
-            Assert.AreEqual(_memoryBlock.Read<int>(0x2020), 0x1234abcd);
+            Assert.That(_memoryBlock.Read<int>(0x2020), Is.EqualTo(0x1234abcd));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace Ryujinx.Tests.Memory
         {
             _memoryBlock.Write(0x2040, 0xbadc0de);
 
-            Assert.AreEqual(Marshal.ReadInt32(_memoryBlock.Pointer, 0x2040), 0xbadc0de);
+            Assert.That(Marshal.ReadInt32(_memoryBlock.Pointer, 0x2040), Is.EqualTo(0xbadc0de));
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace Ryujinx.Tests.Memory
             toAlias.UnmapView(backing, pageSize * 3, pageSize);
 
             toAlias.Write(0, 0xbadc0de);
-            Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, (int)pageSize), 0xbadc0de);
+            Assert.That(Marshal.ReadInt32(backing.Pointer, (int)pageSize), Is.EqualTo(0xbadc0de));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace Ryujinx.Tests.Memory
                     int offset = rng.Next(0, (int)pageSize - sizeof(int));
 
                     toAlias.Write((ulong)((dstPage << pageBits) + offset), 0xbadc0de);
-                    Assert.AreEqual(Marshal.ReadInt32(backing.Pointer, (srcPage << pageBits) + offset), 0xbadc0de);
+                    Assert.That(Marshal.ReadInt32(backing.Pointer, (srcPage << pageBits) + offset), Is.EqualTo(0xbadc0de));
                 }
                 else
                 {
@@ -109,7 +109,7 @@ namespace Ryujinx.Tests.Memory
                 toAlias.MapView(backing, 0, offset, pageSize);
 
                 toAlias.Write(offset, 0xbadc0de);
-                Assert.AreEqual(0xbadc0de, backing.Read<int>(0));
+                Assert.That(0xbadc0de, Is.EqualTo(backing.Read<int>(0)));
 
                 toAlias.UnmapView(backing, offset, pageSize);
             }

--- a/src/Ryujinx.Tests.Memory/TrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/TrackingTests.cs
@@ -53,46 +53,46 @@ namespace Ryujinx.Tests.Memory
             });
 
             bool dirtyInitial = handle.Dirty;
-            Assert.True(dirtyInitial); // Handle starts dirty.
+            Assert.That(dirtyInitial, Is.True); // Handle starts dirty.
 
             handle.Reprotect();
 
             bool dirtyAfterReprotect = handle.Dirty;
-            Assert.False(dirtyAfterReprotect); // Handle is no longer dirty.
+            Assert.That(dirtyAfterReprotect, Is.False); // Handle is no longer dirty.
 
             _tracking.VirtualMemoryEvent(PageSize * 2, 4, true);
             _tracking.VirtualMemoryEvent(PageSize * 2, 4, false);
 
             bool dirtyAfterUnrelatedReadWrite = handle.Dirty;
-            Assert.False(dirtyAfterUnrelatedReadWrite); // Not dirtied, as the write was to an unrelated address.
+            Assert.That(dirtyAfterUnrelatedReadWrite, Is.False); // Not dirtied, as to write was to an unrelated address.
 
-            Assert.IsNull(readTrackingTriggered); // Hasn't been triggered yet
+            Assert.That(readTrackingTriggered, Is.Null); // Hasn't been triggered yet
 
             _tracking.VirtualMemoryEvent(0, 4, false);
 
             bool dirtyAfterRelatedRead = handle.Dirty;
-            Assert.False(dirtyAfterRelatedRead); // Only triggers on write.
-            Assert.AreEqual(readTrackingTriggered, (0UL, 4UL)); // Read action was triggered.
+            Assert.That(dirtyAfterRelatedRead, Is.False); // Only triggers on write.
+            Assert.That(readTrackingTriggered, Is.EqualTo((0UL, 4UL))); // Read action was triggered.
 
             readTrackingTriggered = null;
             _tracking.VirtualMemoryEvent(0, 4, true);
 
             bool dirtyAfterRelatedWrite = handle.Dirty;
-            Assert.True(dirtyAfterRelatedWrite); // Dirty flag should now be set.
+            Assert.That(dirtyAfterRelatedWrite, Is.True); // Dirty flag should now be set.
 
             _tracking.VirtualMemoryEvent(4, 4, true);
             bool dirtyAfterRelatedWrite2 = handle.Dirty;
-            Assert.True(dirtyAfterRelatedWrite2); // Dirty flag should still be set.
+            Assert.That(dirtyAfterRelatedWrite2, Is.True); // Dirty flag should still be set.
 
             handle.Reprotect();
 
             bool dirtyAfterReprotect2 = handle.Dirty;
-            Assert.False(dirtyAfterReprotect2); // Handle is no longer dirty.
+            Assert.That(dirtyAfterReprotect2, Is.False); // Handle is no longer dirty.
 
             handle.Dispose();
 
             bool dirtyAfterDispose = TestSingleWrite(handle, 0, 4);
-            Assert.False(dirtyAfterDispose); // Handle cannot be triggered when disposed
+            Assert.That(dirtyAfterDispose, Is.False); // Handle cannot be triggered when disposed
         }
 
         [Test]
@@ -126,27 +126,27 @@ namespace Ryujinx.Tests.Memory
             for (int i = 0; i < 16; i++)
             {
                 // No handles are dirty.
-                Assert.False(allHandle.Dirty);
-                Assert.IsNull(readTrackingTriggeredAll);
+                Assert.That(allHandle.Dirty, Is.False);
+                Assert.That(readTrackingTriggeredAll, Is.Null);
                 for (int j = 0; j < 16; j++)
                 {
-                    Assert.False(containedHandles[j].Dirty);
+                    Assert.That(containedHandles[j].Dirty, Is.False);
                 }
 
                 _tracking.VirtualMemoryEvent((ulong)i * PageSize, 1, true);
 
                 // Only the handle covering the entire range and the relevant contained handle are dirty.
-                Assert.True(allHandle.Dirty);
-                Assert.AreEqual(readTrackingTriggeredAll, ((ulong)i * PageSize, 1UL)); // Triggered read tracking
+                Assert.That(allHandle.Dirty, Is.True);
+                Assert.That(readTrackingTriggeredAll, Is.EqualTo(((ulong)i * PageSize, 1UL))); // Triggered read tracking
                 for (int j = 0; j < 16; j++)
                 {
                     if (j == i)
                     {
-                        Assert.True(containedHandles[j].Dirty);
+                        Assert.That(containedHandles[j].Dirty, Is.True);
                     }
                     else
                     {
-                        Assert.False(containedHandles[j].Dirty);
+                        Assert.That(containedHandles[j].Dirty, Is.False);
                     }
                 }
 
@@ -171,27 +171,27 @@ namespace Ryujinx.Tests.Memory
             // Anywhere inside the pages the region is contained on should trigger.
 
             bool originalRangeTriggers = TestSingleWrite(handle, address, size);
-            Assert.True(originalRangeTriggers);
+            Assert.That(originalRangeTriggers, Is.True);
 
             bool alignedRangeTriggers = TestSingleWrite(handle, alignedStart, alignedSize);
-            Assert.True(alignedRangeTriggers);
+            Assert.That(alignedRangeTriggers, Is.True);
 
             bool alignedStartTriggers = TestSingleWrite(handle, alignedStart, 1);
-            Assert.True(alignedStartTriggers);
+            Assert.That(alignedStartTriggers, Is.True);
 
             bool alignedEndTriggers = TestSingleWrite(handle, alignedEnd - 1, 1);
-            Assert.True(alignedEndTriggers);
+            Assert.That(alignedEndTriggers, Is.True);
 
             // Outside the tracked range should not trigger.
 
             bool alignedBeforeTriggers = TestSingleWrite(handle, alignedStart - 1, 1);
-            Assert.False(alignedBeforeTriggers);
+            Assert.That(alignedBeforeTriggers, Is.False);
 
             bool alignedAfterTriggers = TestSingleWrite(handle, alignedEnd, 1);
-            Assert.False(alignedAfterTriggers);
+            Assert.That(alignedAfterTriggers, Is.False);
         }
 
-        [Test, Explicit, Timeout(1000)]
+        [Test, Explicit, CancelAfter(1000)]
         public void Multithreading()
         {
             // Multithreading sanity test
@@ -287,9 +287,9 @@ namespace Ryujinx.Tests.Memory
                 thread.Join();
             }
 
-            Assert.Greater(dirtyFlagReprotects, 10);
-            Assert.Greater(writeTriggers, 10);
-            Assert.Greater(handleLifecycles, 10);
+            Assert.That(dirtyFlagReprotects, Is.GreaterThan(10));
+            Assert.That(writeTriggers, Is.GreaterThan(10));
+            Assert.That(handleLifecycles, Is.GreaterThan(10));
         }
 
         [Test]
@@ -354,7 +354,7 @@ namespace Ryujinx.Tests.Memory
 
             // The action should trigger exactly once for every registration,
             // then we register once after all the threads signalling it cease.
-            Assert.AreEqual(registeredCount, triggeredCount + 1);
+            Assert.That(registeredCount, Is.EqualTo(triggeredCount + 1));
         }
 
         [Test]
@@ -365,11 +365,11 @@ namespace Ryujinx.Tests.Memory
             RegionHandle handle = _tracking.BeginTracking(0, PageSize, 0);
             handle.Reprotect();
 
-            Assert.AreEqual(1, _tracking.GetRegionCount());
+            Assert.That(1, Is.EqualTo(_tracking.GetRegionCount()));
 
             handle.Dispose();
 
-            Assert.AreEqual(0, _tracking.GetRegionCount());
+            Assert.That(0, Is.EqualTo(_tracking.GetRegionCount()));
 
             // Two handles, small entirely contains big.
             // We expect there to be three regions after creating both, one for the small region and two covering the big one around it.
@@ -378,16 +378,16 @@ namespace Ryujinx.Tests.Memory
             RegionHandle handleSmall = _tracking.BeginTracking(PageSize, PageSize, 0);
             RegionHandle handleBig = _tracking.BeginTracking(0, PageSize * 4, 0);
 
-            Assert.AreEqual(3, _tracking.GetRegionCount());
+            Assert.That(3, Is.EqualTo(_tracking.GetRegionCount()));
 
             // After disposing the big region, only the small one will remain.
             handleBig.Dispose();
 
-            Assert.AreEqual(1, _tracking.GetRegionCount());
+            Assert.That(1, Is.EqualTo(_tracking.GetRegionCount()));
 
             handleSmall.Dispose();
 
-            Assert.AreEqual(0, _tracking.GetRegionCount());
+            Assert.That(0, Is.EqualTo(_tracking.GetRegionCount()));
         }
 
         [Test]
@@ -397,22 +397,22 @@ namespace Ryujinx.Tests.Memory
 
             _memoryManager.OnProtect += (va, size, newProtection) =>
             {
-                Assert.AreEqual((0, PageSize), (va, size)); // Should protect the exact region all the operations use.
+                Assert.That((0, Is.EqualTo(PageSize)), Is.EqualTo((va, size))); // Should protect the exact region all the operations use.
                 protection = newProtection;
             };
 
             RegionHandle handle = _tracking.BeginTracking(0, PageSize, 0);
 
             // After creating the handle, there is no protection yet.
-            Assert.AreEqual(MemoryPermission.ReadAndWrite, protection);
+            Assert.That(MemoryPermission.ReadAndWrite, Is.EqualTo(protection));
 
             bool dirtyInitial = handle.Dirty;
-            Assert.True(dirtyInitial); // Handle starts dirty.
+            Assert.That(dirtyInitial, Is.True); // Handle starts dirty.
 
             handle.Reprotect();
 
-            // After a reprotect, there is write protection, which will set a dirty flag when any write happens.
-            Assert.AreEqual(MemoryPermission.Read, protection);
+            // After a protection, there is written protection, which will set a dirty flag when any write happens.
+            Assert.That(MemoryPermission.Read, Is.EqualTo(protection));
 
             (ulong address, ulong size)? readTrackingTriggered = null;
             handle.RegisterAction((address, size) =>
@@ -421,34 +421,34 @@ namespace Ryujinx.Tests.Memory
             });
 
             // Registering an action adds read/write protection.
-            Assert.AreEqual(MemoryPermission.None, protection);
+            Assert.That(MemoryPermission.None, Is.EqualTo(protection));
 
             bool dirtyAfterReprotect = handle.Dirty;
-            Assert.False(dirtyAfterReprotect); // Handle is no longer dirty.
+            Assert.That(dirtyAfterReprotect, Is.False); // Handle is no longer dirty.
 
             // First we should read, which will trigger the action. This _should not_ remove write protection on the memory.
 
             _tracking.VirtualMemoryEvent(0, 4, false);
 
             bool dirtyAfterRead = handle.Dirty;
-            Assert.False(dirtyAfterRead); // Not dirtied, as this was a read.
+            Assert.That(dirtyAfterRead, Is.False); // Not dirtied, as this was a read.
 
-            Assert.AreEqual(readTrackingTriggered, (0UL, 4UL)); // Read action was triggered.
+            Assert.That(readTrackingTriggered, Is.EqualTo((0UL, 4UL))); // Read action was triggered.
 
-            Assert.AreEqual(MemoryPermission.Read, protection); // Write protection is still present.
+            Assert.That(MemoryPermission.Read, Is.EqualTo(protection)); // Write protection is still present.
 
             readTrackingTriggered = null;
 
-            // Now, perform a write.
+            // Now, perform a write operation.
 
             _tracking.VirtualMemoryEvent(0, 4, true);
 
             bool dirtyAfterWriteAfterRead = handle.Dirty;
-            Assert.True(dirtyAfterWriteAfterRead); // Should be dirty.
+            Assert.That(dirtyAfterWriteAfterRead, Is.True); // Should be dirty.
 
-            Assert.AreEqual(MemoryPermission.ReadAndWrite, protection); // All protection is now be removed from the memory.
+            Assert.That(MemoryPermission.ReadAndWrite, Is.EqualTo(protection)); // All protection is now be removed from the memory.
 
-            Assert.IsNull(readTrackingTriggered); // Read tracking was removed when the action fired, as it can only fire once.
+            Assert.That(readTrackingTriggered, Is.Null); // Read tracking was removed when the action fired, as it can only fire once.
 
             handle.Dispose();
         }
@@ -476,22 +476,22 @@ namespace Ryujinx.Tests.Memory
 
             _tracking.VirtualMemoryEvent(0, 4, false, precise: true);
 
-            Assert.IsNull(readTrackingTriggered); // Hasn't been triggered - precise action returned true.
-            Assert.AreEqual(preciseTriggered, (0UL, 4UL, false)); // Precise action was triggered.
+            Assert.That(readTrackingTriggered, Is.Null); // Hasn't been triggered - precise action returned true.
+            Assert.That(preciseTriggered, Is.EqualTo((0UL, 4UL, false))); // Precise action was triggered.
 
             _tracking.VirtualMemoryEvent(0, 4, true, precise: true);
 
-            Assert.IsNull(readTrackingTriggered); // Still hasn't been triggered.
+            Assert.That(readTrackingTriggered, Is.Null); // Still hasn't been triggered.
             bool dirtyAfterPreciseActionTrue = handle.Dirty;
-            Assert.False(dirtyAfterPreciseActionTrue); // Not dirtied - precise action returned true.
-            Assert.AreEqual(preciseTriggered, (0UL, 4UL, true)); // Precise action was triggered.
+            Assert.That(dirtyAfterPreciseActionTrue, Is.False); // Not dirtied - precise action returned true.
+            Assert.That(preciseTriggered, Is.EqualTo((0UL, 4UL, true))); // Precise action was triggered.
 
             // Handle is now dirty.
             handle.Reprotect(true);
             preciseTriggered = null;
 
             _tracking.VirtualMemoryEvent(4, 4, true, precise: true);
-            Assert.AreEqual(preciseTriggered, (4UL, 4UL, true)); // Precise action was triggered even though handle was dirty.
+            Assert.That(preciseTriggered, Is.EqualTo((4UL, 4UL, true))); // Precise action was triggered even though handle was dirty.
 
             handle.Reprotect();
             handle.RegisterPreciseAction((address, size, write) =>
@@ -503,10 +503,10 @@ namespace Ryujinx.Tests.Memory
 
             _tracking.VirtualMemoryEvent(8, 4, true, precise: true);
 
-            Assert.AreEqual(readTrackingTriggered, (8UL, 4UL)); // Read action triggered, as precise action returned false.
+            Assert.That(readTrackingTriggered, Is.EqualTo((8UL, 4UL))); // Read action triggered, as precise action returned false.
             bool dirtyAfterPreciseActionFalse = handle.Dirty;
-            Assert.True(dirtyAfterPreciseActionFalse); // Dirtied, as precise action returned false.
-            Assert.AreEqual(preciseTriggered, (8UL, 4UL, true)); // Precise action was triggered.
+            Assert.That(dirtyAfterPreciseActionFalse, Is.True); // Dirtied, as precise action returned false.
+            Assert.That(preciseTriggered, Is.EqualTo((8UL, 4UL, true))); // Precise action was triggered.
         }
     }
 }

--- a/src/Ryujinx.Tests.Memory/TrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/TrackingTests.cs
@@ -191,7 +191,7 @@ namespace Ryujinx.Tests.Memory
             Assert.That(alignedAfterTriggers, Is.False);
         }
 
-        [Test, Explicit, CancelAfter(1000)]
+        [Test, Explicit, Timeout(1000)]
         public void Multithreading()
         {
             // Multithreading sanity test

--- a/src/Ryujinx.Tests.Memory/TrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/TrackingTests.cs
@@ -191,7 +191,7 @@ namespace Ryujinx.Tests.Memory
             Assert.That(alignedAfterTriggers, Is.False);
         }
 
-        [Test, Explicit, Timeout(1000)]
+        [Test, Explicit, CancelAfter(1000)]
         public void Multithreading()
         {
             // Multithreading sanity test

--- a/src/Ryujinx.Tests.Memory/TrackingTests.cs
+++ b/src/Ryujinx.Tests.Memory/TrackingTests.cs
@@ -397,7 +397,7 @@ namespace Ryujinx.Tests.Memory
 
             _memoryManager.OnProtect += (va, size, newProtection) =>
             {
-                Assert.That((0, Is.EqualTo(PageSize)), Is.EqualTo((va, size))); // Should protect the exact region all the operations use.
+                Assert.That((va, size), Is.EqualTo((0UL, (ulong)PageSize))); // Corrected assertion// Should protect the exact region all the operations use.
                 protection = newProtection;
             };
 

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch32.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch32.cs
@@ -113,7 +113,7 @@ namespace Ryujinx.Tests.Unicorn
         public void RunForCount(ulong count)
         {
             // FIXME: untilAddr should be 0xFFFFFFFFFFFFFFFFu
-            Uc.EmuStart(this.PC, -1, 0, (long)count);
+            Uc.EmuStart((long)this.PC, unchecked((long)ulong.MaxValue), 0, (long)count);
         }
 
         public void Step()

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
@@ -97,10 +97,7 @@ namespace Ryujinx.Tests.Unicorn
                 return;
             }
 
-            if (Uc != null)
-            {
-                Uc.Close();
-            }
+            Uc?.Close();
 
             _isDisposed = true;
         }

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
@@ -103,6 +103,9 @@ namespace Ryujinx.Tests.Unicorn
         {
             // FIXME: untilAddr should be 0xFFFFFFFFFFFFFFFFul
             Uc.EmuStart((long)this.PC, -1, 0, (long)count);
+            
+            // ulong.MaxValue instead of -1 to avoid NullReferenceException
+            Uc.EmuStart((long)this.PC, unchecked((long)ulong.MaxValue), 0, (long)count);
         }
 
         public void Step()

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
@@ -101,9 +101,6 @@ namespace Ryujinx.Tests.Unicorn
 
         public void RunForCount(ulong count)
         {
-            // FIXME: untilAddr should be 0xFFFFFFFFFFFFFFFFul
-            Uc.EmuStart((long)this.PC, -1, 0, (long)count);
-            
             // ulong.MaxValue instead of -1 to avoid NullReferenceException
             Uc.EmuStart((long)this.PC, unchecked((long)ulong.MaxValue), 0, (long)count);
         }

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
@@ -92,17 +92,23 @@ namespace Ryujinx.Tests.Unicorn
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!_isDisposed)
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            if (Uc != null)
             {
                 Uc.Close();
-                _isDisposed = true;
             }
+
+            _isDisposed = true;
         }
 
         public void RunForCount(ulong count)
         {
-            // FIXME: untilAddr should be 0xFFFFFFFFFFFFFFFFul
-            Uc.EmuStart((long)this.PC, -1, 0, (long)count);
+            // ulong.MaxValue instead of -1 to avoid NullReferenceException
+            Uc.EmuStart((long)this.PC, unchecked((long)ulong.MaxValue), 0, (long)count);
         }
 
         public void Step()
@@ -112,73 +118,26 @@ namespace Ryujinx.Tests.Unicorn
 
         private static readonly int[] _xRegisters =
         {
-            Arm64.UC_ARM64_REG_X0,
-            Arm64.UC_ARM64_REG_X1,
-            Arm64.UC_ARM64_REG_X2,
-            Arm64.UC_ARM64_REG_X3,
-            Arm64.UC_ARM64_REG_X4,
-            Arm64.UC_ARM64_REG_X5,
-            Arm64.UC_ARM64_REG_X6,
-            Arm64.UC_ARM64_REG_X7,
-            Arm64.UC_ARM64_REG_X8,
-            Arm64.UC_ARM64_REG_X9,
-            Arm64.UC_ARM64_REG_X10,
-            Arm64.UC_ARM64_REG_X11,
-            Arm64.UC_ARM64_REG_X12,
-            Arm64.UC_ARM64_REG_X13,
-            Arm64.UC_ARM64_REG_X14,
-            Arm64.UC_ARM64_REG_X15,
-            Arm64.UC_ARM64_REG_X16,
-            Arm64.UC_ARM64_REG_X17,
-            Arm64.UC_ARM64_REG_X18,
-            Arm64.UC_ARM64_REG_X19,
-            Arm64.UC_ARM64_REG_X20,
-            Arm64.UC_ARM64_REG_X21,
-            Arm64.UC_ARM64_REG_X22,
-            Arm64.UC_ARM64_REG_X23,
-            Arm64.UC_ARM64_REG_X24,
-            Arm64.UC_ARM64_REG_X25,
-            Arm64.UC_ARM64_REG_X26,
-            Arm64.UC_ARM64_REG_X27,
-            Arm64.UC_ARM64_REG_X28,
-            Arm64.UC_ARM64_REG_X29,
-            Arm64.UC_ARM64_REG_X30,
+            Arm64.UC_ARM64_REG_X0, Arm64.UC_ARM64_REG_X1, Arm64.UC_ARM64_REG_X2, Arm64.UC_ARM64_REG_X3,
+            Arm64.UC_ARM64_REG_X4, Arm64.UC_ARM64_REG_X5, Arm64.UC_ARM64_REG_X6, Arm64.UC_ARM64_REG_X7,
+            Arm64.UC_ARM64_REG_X8, Arm64.UC_ARM64_REG_X9, Arm64.UC_ARM64_REG_X10, Arm64.UC_ARM64_REG_X11,
+            Arm64.UC_ARM64_REG_X12, Arm64.UC_ARM64_REG_X13, Arm64.UC_ARM64_REG_X14, Arm64.UC_ARM64_REG_X15,
+            Arm64.UC_ARM64_REG_X16, Arm64.UC_ARM64_REG_X17, Arm64.UC_ARM64_REG_X18, Arm64.UC_ARM64_REG_X19,
+            Arm64.UC_ARM64_REG_X20, Arm64.UC_ARM64_REG_X21, Arm64.UC_ARM64_REG_X22, Arm64.UC_ARM64_REG_X23,
+            Arm64.UC_ARM64_REG_X24, Arm64.UC_ARM64_REG_X25, Arm64.UC_ARM64_REG_X26, Arm64.UC_ARM64_REG_X27,
+            Arm64.UC_ARM64_REG_X28, Arm64.UC_ARM64_REG_X29, Arm64.UC_ARM64_REG_X30,
         };
 
         private static readonly int[] _qRegisters =
         {
-            Arm64.UC_ARM64_REG_Q0,
-            Arm64.UC_ARM64_REG_Q1,
-            Arm64.UC_ARM64_REG_Q2,
-            Arm64.UC_ARM64_REG_Q3,
-            Arm64.UC_ARM64_REG_Q4,
-            Arm64.UC_ARM64_REG_Q5,
-            Arm64.UC_ARM64_REG_Q6,
-            Arm64.UC_ARM64_REG_Q7,
-            Arm64.UC_ARM64_REG_Q8,
-            Arm64.UC_ARM64_REG_Q9,
-            Arm64.UC_ARM64_REG_Q10,
-            Arm64.UC_ARM64_REG_Q11,
-            Arm64.UC_ARM64_REG_Q12,
-            Arm64.UC_ARM64_REG_Q13,
-            Arm64.UC_ARM64_REG_Q14,
-            Arm64.UC_ARM64_REG_Q15,
-            Arm64.UC_ARM64_REG_Q16,
-            Arm64.UC_ARM64_REG_Q17,
-            Arm64.UC_ARM64_REG_Q18,
-            Arm64.UC_ARM64_REG_Q19,
-            Arm64.UC_ARM64_REG_Q20,
-            Arm64.UC_ARM64_REG_Q21,
-            Arm64.UC_ARM64_REG_Q22,
-            Arm64.UC_ARM64_REG_Q23,
-            Arm64.UC_ARM64_REG_Q24,
-            Arm64.UC_ARM64_REG_Q25,
-            Arm64.UC_ARM64_REG_Q26,
-            Arm64.UC_ARM64_REG_Q27,
-            Arm64.UC_ARM64_REG_Q28,
-            Arm64.UC_ARM64_REG_Q29,
-            Arm64.UC_ARM64_REG_Q30,
-            Arm64.UC_ARM64_REG_Q31,
+            Arm64.UC_ARM64_REG_Q0, Arm64.UC_ARM64_REG_Q1, Arm64.UC_ARM64_REG_Q2, Arm64.UC_ARM64_REG_Q3,
+            Arm64.UC_ARM64_REG_Q4, Arm64.UC_ARM64_REG_Q5, Arm64.UC_ARM64_REG_Q6, Arm64.UC_ARM64_REG_Q7,
+            Arm64.UC_ARM64_REG_Q8, Arm64.UC_ARM64_REG_Q9, Arm64.UC_ARM64_REG_Q10, Arm64.UC_ARM64_REG_Q11,
+            Arm64.UC_ARM64_REG_Q12, Arm64.UC_ARM64_REG_Q13, Arm64.UC_ARM64_REG_Q14, Arm64.UC_ARM64_REG_Q15,
+            Arm64.UC_ARM64_REG_Q16, Arm64.UC_ARM64_REG_Q17, Arm64.UC_ARM64_REG_Q18, Arm64.UC_ARM64_REG_Q19,
+            Arm64.UC_ARM64_REG_Q20, Arm64.UC_ARM64_REG_Q21, Arm64.UC_ARM64_REG_Q22, Arm64.UC_ARM64_REG_Q23,
+            Arm64.UC_ARM64_REG_Q24, Arm64.UC_ARM64_REG_Q25, Arm64.UC_ARM64_REG_Q26, Arm64.UC_ARM64_REG_Q27,
+            Arm64.UC_ARM64_REG_Q28, Arm64.UC_ARM64_REG_Q29, Arm64.UC_ARM64_REG_Q30, Arm64.UC_ARM64_REG_Q31,
         };
 
         public ulong GetX(int index)

--- a/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
+++ b/src/Ryujinx.Tests.Unicorn/UnicornAArch64.cs
@@ -101,8 +101,8 @@ namespace Ryujinx.Tests.Unicorn
 
         public void RunForCount(ulong count)
         {
-            // ulong.MaxValue instead of -1 to avoid NullReferenceException
-            Uc.EmuStart((long)this.PC, unchecked((long)ulong.MaxValue), 0, (long)count);
+            // FIXME: untilAddr should be 0xFFFFFFFFFFFFFFFFul
+            Uc.EmuStart((long)this.PC, -1, 0, (long)count);
         }
 
         public void Step()

--- a/src/Ryujinx.Tests/Audio/Renderer/AudioRendererConfigurationTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/AudioRendererConfigurationTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x34, Unsafe.SizeOf<AudioRendererConfiguration>());
+            Assert.That(0x34, Is.EqualTo(Unsafe.SizeOf<AudioRendererConfiguration>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/BehaviourParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/BehaviourParameterTests.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<BehaviourParameter>());
-            Assert.AreEqual(0x10, Unsafe.SizeOf<BehaviourParameter.ErrorInfo>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<BehaviourParameter>()));
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<BehaviourParameter.ErrorInfo>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/BiquadFilterParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/BiquadFilterParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0xC, Unsafe.SizeOf<BiquadFilterParameter>());
+            Assert.That(0xC, Is.EqualTo(Unsafe.SizeOf<BiquadFilterParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Common/UpdateDataHeaderTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Common/UpdateDataHeaderTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Common
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x40, Unsafe.SizeOf<UpdateDataHeader>());
+            Assert.That(0x40, Is.EqualTo(Unsafe.SizeOf<UpdateDataHeader>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Common/VoiceUpdateStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Common/VoiceUpdateStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Common
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.LessOrEqual(Unsafe.SizeOf<VoiceUpdateState>(), 0x100);
+            Assert.That(Unsafe.SizeOf<VoiceUpdateState>(), Is.LessThanOrEqualTo(0x100));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Common/WaveBufferTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Common/WaveBufferTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Common
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x30, Unsafe.SizeOf<WaveBuffer>());
+            Assert.That(0x30, Is.EqualTo(Unsafe.SizeOf<WaveBuffer>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Dsp/ResamplerTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Dsp/ResamplerTests.cs
@@ -74,13 +74,13 @@ namespace Ryujinx.Tests.Audio.Renderer.Dsp
                 float thisDelta = Math.Abs(expectedOutput[sample] - outputBuffer[sample]);
 
                 // Ensure no discontinuities
-                Assert.IsTrue(thisDelta < 0.1f);
+                Assert.That(thisDelta < 0.1f, Is.True);
                 sumDifference += thisDelta;
             }
 
             sumDifference /= outputSampleCount;
             // Expect the output to be 99% similar to the expected resampled sine wave
-            Assert.IsTrue(sumDifference < 0.01f);
+            Assert.That(sumDifference < 0.01f, Is.True);
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Dsp/UpsamplerTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Dsp/UpsamplerTests.cs
@@ -51,7 +51,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Dsp
 
             sumDifference /= expectedOutput.Length;
             // Expect the output to be 98% similar to the expected resampled sine wave
-            Assert.IsTrue(sumDifference < 0.02f);
+            Assert.That(sumDifference < 0.02f, Is.True);
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/EffectInfoParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/EffectInfoParameterTests.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0xC0, Unsafe.SizeOf<EffectInParameterVersion1>());
-            Assert.AreEqual(0xC0, Unsafe.SizeOf<EffectInParameterVersion2>());
+            Assert.That(0xC0, Is.EqualTo(Unsafe.SizeOf<EffectInParameterVersion1>()));
+            Assert.That(0xC0, Is.EqualTo(Unsafe.SizeOf<EffectInParameterVersion2>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/EffectOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/EffectOutStatusTests.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<EffectOutStatusVersion1>());
-            Assert.AreEqual(0x90, Unsafe.SizeOf<EffectOutStatusVersion2>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<EffectOutStatusVersion1>()));
+            Assert.That(0x90, Is.EqualTo(Unsafe.SizeOf<EffectOutStatusVersion2>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/MemoryPoolParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/MemoryPoolParameterTests.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<MemoryPoolInParameter>());
-            Assert.AreEqual(0x10, Unsafe.SizeOf<MemoryPoolOutStatus>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<MemoryPoolInParameter>()));
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<MemoryPoolOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/BehaviourErrorInfoOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/BehaviourErrorInfoOutStatusTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0xB0, Unsafe.SizeOf<BehaviourErrorInfoOutStatus>());
+            Assert.That(0xB0, Is.EqualTo(Unsafe.SizeOf<BehaviourErrorInfoOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/AuxParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/AuxParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x6C, Unsafe.SizeOf<AuxiliaryBufferParameter>());
+            Assert.That(0x6C, Is.EqualTo(Unsafe.SizeOf<AuxiliaryBufferParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/BiquadFilterEffectParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/BiquadFilterEffectParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x18, Unsafe.SizeOf<BiquadFilterEffectParameter>());
+            Assert.That(0x18, Is.EqualTo(Unsafe.SizeOf<BiquadFilterEffectParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/BufferMixerParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/BufferMixerParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x94, Unsafe.SizeOf<BufferMixParameter>());
+            Assert.That(0x94, Is.EqualTo(Unsafe.SizeOf<BufferMixParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/CompressorParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/CompressorParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x38, Unsafe.SizeOf<CompressorParameter>());
+            Assert.That(0x38, Is.EqualTo(Unsafe.SizeOf<CompressorParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/DelayParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/DelayParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x35, Unsafe.SizeOf<DelayParameter>());
+            Assert.That(0x35, Is.EqualTo(Unsafe.SizeOf<DelayParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/LimiterParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/LimiterParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x44, Unsafe.SizeOf<LimiterParameter>());
+            Assert.That(0x44, Is.EqualTo(Unsafe.SizeOf<LimiterParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/LimiterStatisticsTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/LimiterStatisticsTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x30, Unsafe.SizeOf<LimiterStatistics>());
+            Assert.That(0x30, Is.EqualTo(Unsafe.SizeOf<LimiterStatistics>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/Reverb3dParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/Reverb3dParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x49, Unsafe.SizeOf<Reverb3dParameter>());
+            Assert.That(0x49, Is.EqualTo(Unsafe.SizeOf<Reverb3dParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/ReverbParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Effect/ReverbParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Effect
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x41, Unsafe.SizeOf<ReverbParameter>());
+            Assert.That(0x41, Is.EqualTo(Unsafe.SizeOf<ReverbParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/MixInParameterDirtyOnlyUpdateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/MixInParameterDirtyOnlyUpdateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<MixInParameterDirtyOnlyUpdate>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<MixInParameterDirtyOnlyUpdate>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/MixParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/MixParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x930, Unsafe.SizeOf<MixParameter>());
+            Assert.That(0x930, Is.EqualTo(Unsafe.SizeOf<MixParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/PerformanceInParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/PerformanceInParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<PerformanceInParameter>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<PerformanceInParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/PerformanceOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/PerformanceOutStatusTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<PerformanceOutStatus>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<PerformanceOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/RendererInfoOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/RendererInfoOutStatusTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<RendererInfoOutStatus>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<RendererInfoOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Sink/CircularBufferParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Sink/CircularBufferParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Sink
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x24, Unsafe.SizeOf<CircularBufferParameter>());
+            Assert.That(0x24, Is.EqualTo(Unsafe.SizeOf<CircularBufferParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/Sink/DeviceParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/Sink/DeviceParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter.Sink
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x11C, Unsafe.SizeOf<DeviceParameter>());
+            Assert.That(0x11C, Is.EqualTo(Unsafe.SizeOf<DeviceParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/SinkInParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/SinkInParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x140, Unsafe.SizeOf<SinkInParameter>());
+            Assert.That(0x140, Is.EqualTo(Unsafe.SizeOf<SinkInParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/SinkOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/SinkOutStatusTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<SinkOutStatus>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<SinkOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Parameter/SplitterInParamHeaderTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Parameter/SplitterInParamHeaderTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Parameter
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<SplitterInParameterHeader>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<SplitterInParameterHeader>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/AddressInfoTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/AddressInfoTests.cs
@@ -10,7 +10,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<AddressInfo>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<AddressInfo>()));
         }
 
         [Test]
@@ -25,11 +25,11 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             addressInfo.ForceMappedDspAddress = 0x2000000;
 
-            Assert.AreEqual(0x2000000, addressInfo.GetReference(true));
+            Assert.That(0x2000000, Is.EqualTo(addressInfo.GetReference(true)));
 
             addressInfo.SetupMemoryPool(memoryPoolState.AsSpan());
 
-            Assert.AreEqual(0x4000000, addressInfo.GetReference(true));
+            Assert.That(0x4000000, Is.EqualTo(addressInfo.GetReference(true)));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/BehaviourContextTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/BehaviourContextTests.cs
@@ -12,11 +12,11 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
             int previousRevision = BehaviourContext.BaseRevisionMagic + (BehaviourContext.LastRevision - 1);
             int invalidRevision = BehaviourContext.BaseRevisionMagic + (BehaviourContext.LastRevision + 1);
 
-            Assert.IsTrue(BehaviourContext.CheckFeatureSupported(latestRevision, latestRevision));
-            Assert.IsFalse(BehaviourContext.CheckFeatureSupported(previousRevision, latestRevision));
-            Assert.IsTrue(BehaviourContext.CheckFeatureSupported(latestRevision, previousRevision));
-            // In case we get an invalid revision, this is supposed to auto default to REV1 internally.. idk what the hell Nintendo was thinking here..
-            Assert.IsTrue(BehaviourContext.CheckFeatureSupported(invalidRevision, latestRevision));
+            Assert.That(BehaviourContext.CheckFeatureSupported(latestRevision, latestRevision), Is.True);
+            Assert.That(BehaviourContext.CheckFeatureSupported(previousRevision, latestRevision), Is.False);
+            Assert.That(BehaviourContext.CheckFeatureSupported(latestRevision, previousRevision), Is.True);
+            // In case we get an invalid revision, this is supposed to auto default to REV1 internally. IDK what the hell Nintendo was thinking here.
+            Assert.That(BehaviourContext.CheckFeatureSupported(invalidRevision, latestRevision), Is.True);
         }
 
         [Test]
@@ -26,11 +26,11 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision1);
 
-            Assert.IsFalse(behaviourContext.IsMemoryPoolForceMappingEnabled());
+            Assert.That(behaviourContext.IsMemoryPoolForceMappingEnabled(), Is.False);
 
             behaviourContext.UpdateFlags(0x1);
 
-            Assert.IsTrue(behaviourContext.IsMemoryPoolForceMappingEnabled());
+            Assert.That(behaviourContext.IsMemoryPoolForceMappingEnabled(), Is.True);
         }
 
         [Test]
@@ -40,26 +40,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision1);
 
-            Assert.IsFalse(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsFalse(behaviourContext.IsSplitterSupported());
-            Assert.IsFalse(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsFalse(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsFalse(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsFalse(behaviourContext.IsSplitterBugFixed());
-            Assert.IsFalse(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsFalse(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.False);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.False);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.False);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.False);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.False);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.70f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(1, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(1, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.70f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -69,26 +69,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision2);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsFalse(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsFalse(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsFalse(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsFalse(behaviourContext.IsSplitterBugFixed());
-            Assert.IsFalse(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsFalse(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.False);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.False);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.False);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.False);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.70f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(1, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(1, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.70f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -98,26 +98,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision3);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsFalse(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsFalse(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsFalse(behaviourContext.IsSplitterBugFixed());
-            Assert.IsFalse(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsFalse(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.False);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.False);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.False);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.70f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(1, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(1, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.70f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -127,26 +127,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision4);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsFalse(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsFalse(behaviourContext.IsSplitterBugFixed());
-            Assert.IsFalse(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsFalse(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.False);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.False);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.75f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(1, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(1, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.75f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(1, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -156,26 +156,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision5);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.False);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(2, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -185,26 +185,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision6);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsFalse(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.False);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(2, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -214,26 +214,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision7);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsFalse(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(2, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -243,26 +243,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision8);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsFalse(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.False);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(3, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(3, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -272,26 +272,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision9);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsTrue(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsFalse(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.False);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(3, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(3, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -301,26 +301,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision10);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsTrue(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsTrue(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsFalse(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.True);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.False);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(4, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(4, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -330,26 +330,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision11);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsTrue(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsTrue(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsTrue(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsFalse(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.True);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.False);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(5, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(5, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -359,26 +359,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision12);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsTrue(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsTrue(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsTrue(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsFalse(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.True);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.True);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.False);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(5, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(5, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
 
         [Test]
@@ -388,26 +388,26 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             behaviourContext.SetUserRevision(BehaviourContext.BaseRevisionMagic + BehaviourContext.Revision13);
 
-            Assert.IsTrue(behaviourContext.IsAdpcmLoopContextBugFixed());
-            Assert.IsTrue(behaviourContext.IsSplitterSupported());
-            Assert.IsTrue(behaviourContext.IsLongSizePreDelaySupported());
-            Assert.IsTrue(behaviourContext.IsAudioUsbDeviceOutputSupported());
-            Assert.IsTrue(behaviourContext.IsFlushVoiceWaveBuffersSupported());
-            Assert.IsTrue(behaviourContext.IsSplitterBugFixed());
-            Assert.IsTrue(behaviourContext.IsElapsedFrameCountSupported());
-            Assert.IsTrue(behaviourContext.IsDecodingBehaviourFlagSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterEffectStateClearBugFixed());
-            Assert.IsTrue(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported());
-            Assert.IsTrue(behaviourContext.IsWaveBufferVersion2Supported());
-            Assert.IsTrue(behaviourContext.IsEffectInfoVersion2Supported());
-            Assert.IsTrue(behaviourContext.UseMultiTapBiquadFilterProcessing());
-            Assert.IsTrue(behaviourContext.IsNewEffectChannelMappingSupported());
-            Assert.IsTrue(behaviourContext.IsBiquadFilterParameterForSplitterEnabled());
-            Assert.IsTrue(behaviourContext.IsSplitterPrevVolumeResetSupported());
+            Assert.That(behaviourContext.IsAdpcmLoopContextBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsSplitterSupported(), Is.True);
+            Assert.That(behaviourContext.IsLongSizePreDelaySupported(), Is.True);
+            Assert.That(behaviourContext.IsAudioUsbDeviceOutputSupported(), Is.True);
+            Assert.That(behaviourContext.IsFlushVoiceWaveBuffersSupported(), Is.True);
+            Assert.That(behaviourContext.IsSplitterBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsElapsedFrameCountSupported(), Is.True);
+            Assert.That(behaviourContext.IsDecodingBehaviourFlagSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterEffectStateClearBugFixed(), Is.True);
+            Assert.That(behaviourContext.IsMixInParameterDirtyOnlyUpdateSupported(), Is.True);
+            Assert.That(behaviourContext.IsWaveBufferVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.IsEffectInfoVersion2Supported(), Is.True);
+            Assert.That(behaviourContext.UseMultiTapBiquadFilterProcessing(), Is.True);
+            Assert.That(behaviourContext.IsNewEffectChannelMappingSupported(), Is.True);
+            Assert.That(behaviourContext.IsBiquadFilterParameterForSplitterEnabled(), Is.True);
+            Assert.That(behaviourContext.IsSplitterPrevVolumeResetSupported(), Is.True);
 
-            Assert.AreEqual(0.80f, behaviourContext.GetAudioRendererProcessingTimeLimit());
-            Assert.AreEqual(5, behaviourContext.GetCommandProcessingTimeEstimatorVersion());
-            Assert.AreEqual(2, behaviourContext.GetPerformanceMetricsDataFormat());
+            Assert.That(0.80f, Is.EqualTo(behaviourContext.GetAudioRendererProcessingTimeLimit()));
+            Assert.That(5, Is.EqualTo(behaviourContext.GetCommandProcessingTimeEstimatorVersion()));
+            Assert.That(2, Is.EqualTo(behaviourContext.GetPerformanceMetricsDataFormat()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/MemoryPoolStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/MemoryPoolStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(Unsafe.SizeOf<MemoryPoolState>(), 0x20);
+            Assert.That(Unsafe.SizeOf<MemoryPoolState>(), Is.EqualTo(0x20));
         }
 
         [Test]
@@ -21,12 +21,12 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             memoryPool.DspAddress = 0x2000000;
 
-            Assert.IsTrue(memoryPool.Contains(0x1000000, 0x10));
-            Assert.IsTrue(memoryPool.Contains(0x1000FE0, 0x10));
-            Assert.IsTrue(memoryPool.Contains(0x1000FFF, 0x1));
-            Assert.IsFalse(memoryPool.Contains(0x1000FFF, 0x2));
-            Assert.IsFalse(memoryPool.Contains(0x1001000, 0x10));
-            Assert.IsFalse(memoryPool.Contains(0x2000000, 0x10));
+            Assert.That(memoryPool.Contains(0x1000000, 0x10), Is.True);
+            Assert.That(memoryPool.Contains(0x1000FE0, 0x10), Is.True);
+            Assert.That(memoryPool.Contains(0x1000FFF, 0x1), Is.True);
+            Assert.That(memoryPool.Contains(0x1000FFF, 0x2), Is.False);
+            Assert.That(memoryPool.Contains(0x1001000, 0x10), Is.False);
+            Assert.That(memoryPool.Contains(0x2000000, 0x10), Is.False);
         }
 
         [Test]
@@ -38,11 +38,11 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             memoryPool.DspAddress = 0x2000000;
 
-            Assert.AreEqual(0x2000FE0, memoryPool.Translate(0x1000FE0, 0x10));
-            Assert.AreEqual(0x2000FFF, memoryPool.Translate(0x1000FFF, 0x1));
-            Assert.AreEqual(0x0, memoryPool.Translate(0x1000FFF, 0x2));
-            Assert.AreEqual(0x0, memoryPool.Translate(0x1001000, 0x10));
-            Assert.AreEqual(0x0, memoryPool.Translate(0x2000000, 0x10));
+            Assert.That(0x2000FE0, Is.EqualTo(memoryPool.Translate(0x1000FE0, 0x10)));
+            Assert.That(0x2000FFF, Is.EqualTo(memoryPool.Translate(0x1000FFF, 0x1)));
+            Assert.That(0x0, Is.EqualTo(memoryPool.Translate(0x1000FFF, 0x2)));
+            Assert.That(0x0, Is.EqualTo(memoryPool.Translate(0x1001000, 0x10)));
+            Assert.That(0x0, Is.EqualTo(memoryPool.Translate(0x2000000, 0x10)));
         }
 
         [Test]
@@ -52,11 +52,11 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             memoryPool.SetCpuAddress(0x1000000, 0x1000);
 
-            Assert.IsFalse(memoryPool.IsMapped());
+            Assert.That(memoryPool.IsMapped(), Is.False);
 
             memoryPool.DspAddress = 0x2000000;
 
-            Assert.IsTrue(memoryPool.IsMapped());
+            Assert.That(memoryPool.IsMapped(), Is.True);
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/MixStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/MixStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x940, Unsafe.SizeOf<MixState>());
+            Assert.That(0x940, Is.EqualTo(Unsafe.SizeOf<MixState>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/PoolMapperTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/PoolMapperTests.cs
@@ -64,7 +64,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
             memoryPoolDsp.IsUsed = true;
             Assert.That(poolMapper.Unmap(ref memoryPoolDsp), Is.False);
             memoryPoolDsp.IsUsed = false;
-            Assert.That(poolMapper.Unmap(ref memoryPoolDsp), Is.False);
+            Assert.That(poolMapper.Unmap(ref memoryPoolDsp), Is.True);
         }
 
         [Test]

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/PoolMapperTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/PoolMapperTests.cs
@@ -23,12 +23,12 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
             const DspAddress DspAddress = CpuAddress; // TODO: DSP LLE
             const ulong CpuSize = 0x1000;
 
-            Assert.IsFalse(poolMapper.InitializeSystemPool(ref memoryPoolCpu, CpuAddress, CpuSize));
-            Assert.IsTrue(poolMapper.InitializeSystemPool(ref memoryPoolDsp, CpuAddress, CpuSize));
+            Assert.That(poolMapper.InitializeSystemPool(ref memoryPoolCpu, CpuAddress, CpuSize), Is.False);
+            Assert.That(poolMapper.InitializeSystemPool(ref memoryPoolDsp, CpuAddress, CpuSize), Is.True);
 
-            Assert.AreEqual(CpuAddress, memoryPoolDsp.CpuAddress);
-            Assert.AreEqual(CpuSize, memoryPoolDsp.Size);
-            Assert.AreEqual(DspAddress, memoryPoolDsp.DspAddress);
+            Assert.That(CpuAddress, Is.EqualTo(memoryPoolDsp.CpuAddress));
+            Assert.That(CpuSize, Is.EqualTo(memoryPoolDsp.Size));
+            Assert.That(DspAddress, Is.EqualTo(memoryPoolDsp.DspAddress));
         }
 
         [Test]
@@ -38,8 +38,8 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
             MemoryPoolState memoryPoolDsp = MemoryPoolState.Create(MemoryPoolState.LocationType.Dsp);
             MemoryPoolState memoryPoolCpu = MemoryPoolState.Create(MemoryPoolState.LocationType.Cpu);
 
-            Assert.AreEqual(0xFFFF8001, poolMapper.GetProcessHandle(ref memoryPoolCpu));
-            Assert.AreEqual(DummyProcessHandle, poolMapper.GetProcessHandle(ref memoryPoolDsp));
+            Assert.That(0xFFFF8001, Is.EqualTo(poolMapper.GetProcessHandle(ref memoryPoolCpu)));
+            Assert.That(DummyProcessHandle, Is.EqualTo(poolMapper.GetProcessHandle(ref memoryPoolDsp)));
         }
 
         [Test]
@@ -56,15 +56,15 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
             memoryPoolDsp.SetCpuAddress(CpuAddress, CpuSize);
             memoryPoolCpu.SetCpuAddress(CpuAddress, CpuSize);
 
-            Assert.AreEqual(DspAddress, poolMapper.Map(ref memoryPoolCpu));
-            Assert.AreEqual(DspAddress, poolMapper.Map(ref memoryPoolDsp));
-            Assert.AreEqual(DspAddress, memoryPoolDsp.DspAddress);
-            Assert.IsTrue(poolMapper.Unmap(ref memoryPoolCpu));
+            Assert.That(DspAddress, Is.EqualTo(poolMapper.Map(ref memoryPoolCpu)));
+            Assert.That(DspAddress, Is.EqualTo(poolMapper.Map(ref memoryPoolDsp)));
+            Assert.That(DspAddress, Is.EqualTo(memoryPoolDsp.DspAddress));
+            Assert.That(poolMapper.Unmap(ref memoryPoolCpu), Is.True);
 
             memoryPoolDsp.IsUsed = true;
-            Assert.IsFalse(poolMapper.Unmap(ref memoryPoolDsp));
+            Assert.That(poolMapper.Unmap(ref memoryPoolDsp), Is.False);
             memoryPoolDsp.IsUsed = false;
-            Assert.IsTrue(poolMapper.Unmap(ref memoryPoolDsp));
+            Assert.That(poolMapper.Unmap(ref memoryPoolDsp), Is.False);
         }
 
         [Test]
@@ -90,45 +90,45 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
 
             PoolMapper poolMapper = new(DummyProcessHandle, true);
 
-            Assert.IsTrue(poolMapper.TryAttachBuffer(out ErrorInfo errorInfo, ref addressInfo, 0, 0));
+            Assert.That(poolMapper.TryAttachBuffer(out ErrorInfo errorInfo, ref addressInfo, 0, 0), Is.True);
 
-            Assert.AreEqual(ResultCode.InvalidAddressInfo, errorInfo.ErrorCode);
-            Assert.AreEqual(0, errorInfo.ExtraErrorInfo);
-            Assert.AreEqual(0, addressInfo.ForceMappedDspAddress);
+            Assert.That(ResultCode.InvalidAddressInfo, Is.EqualTo(errorInfo.ErrorCode));
+            Assert.That(0, Is.EqualTo(errorInfo.ExtraErrorInfo));
+            Assert.That(0, Is.EqualTo(addressInfo.ForceMappedDspAddress));
 
-            Assert.IsTrue(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize));
+            Assert.That(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize), Is.True);
 
-            Assert.AreEqual(ResultCode.InvalidAddressInfo, errorInfo.ErrorCode);
-            Assert.AreEqual(CpuAddress, errorInfo.ExtraErrorInfo);
-            Assert.AreEqual(DspAddress, addressInfo.ForceMappedDspAddress);
+            Assert.That(ResultCode.InvalidAddressInfo, Is.EqualTo(errorInfo.ErrorCode));
+            Assert.That(CpuAddress, Is.EqualTo(errorInfo.ExtraErrorInfo));
+            Assert.That(DspAddress, Is.EqualTo(addressInfo.ForceMappedDspAddress));
 
             poolMapper = new PoolMapper(DummyProcessHandle, false);
 
-            Assert.IsFalse(poolMapper.TryAttachBuffer(out _, ref addressInfo, 0, 0));
+            Assert.That(poolMapper.TryAttachBuffer(out _, ref addressInfo, 0, 0), Is.False);
 
             addressInfo.ForceMappedDspAddress = 0;
 
-            Assert.IsFalse(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize));
+            Assert.That(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize), Is.False);
 
-            Assert.AreEqual(ResultCode.InvalidAddressInfo, errorInfo.ErrorCode);
-            Assert.AreEqual(CpuAddress, errorInfo.ExtraErrorInfo);
-            Assert.AreEqual(0, addressInfo.ForceMappedDspAddress);
+            Assert.That(ResultCode.InvalidAddressInfo, Is.EqualTo(errorInfo.ErrorCode));
+            Assert.That(CpuAddress, Is.EqualTo(errorInfo.ExtraErrorInfo));
+            Assert.That(0, Is.EqualTo(addressInfo.ForceMappedDspAddress));
 
             poolMapper = new PoolMapper(DummyProcessHandle, memoryPoolStateArray.AsMemory(), false);
 
-            Assert.IsFalse(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddressRegionEnding, CpuSize));
+            Assert.That(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddressRegionEnding, CpuSize), Is.False);
 
-            Assert.AreEqual(ResultCode.InvalidAddressInfo, errorInfo.ErrorCode);
-            Assert.AreEqual(CpuAddressRegionEnding, errorInfo.ExtraErrorInfo);
-            Assert.AreEqual(0, addressInfo.ForceMappedDspAddress);
-            Assert.IsFalse(addressInfo.HasMemoryPoolState);
+            Assert.That(ResultCode.InvalidAddressInfo, Is.EqualTo(errorInfo.ErrorCode));
+            Assert.That(CpuAddressRegionEnding, Is.EqualTo(errorInfo.ExtraErrorInfo));
+            Assert.That(0, Is.EqualTo(addressInfo.ForceMappedDspAddress));
+            Assert.That(addressInfo.HasMemoryPoolState, Is.False);
 
-            Assert.IsTrue(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize));
+            Assert.That(poolMapper.TryAttachBuffer(out errorInfo, ref addressInfo, CpuAddress, CpuSize), Is.True);
 
-            Assert.AreEqual(ResultCode.Success, errorInfo.ErrorCode);
-            Assert.AreEqual(0, errorInfo.ExtraErrorInfo);
-            Assert.AreEqual(0, addressInfo.ForceMappedDspAddress);
-            Assert.IsTrue(addressInfo.HasMemoryPoolState);
+            Assert.That(ResultCode.Success, Is.EqualTo(errorInfo.ErrorCode));
+            Assert.That(0, Is.EqualTo(errorInfo.ExtraErrorInfo));
+            Assert.That(0, Is.EqualTo(addressInfo.ForceMappedDspAddress));
+            Assert.That(addressInfo.HasMemoryPoolState, Is.True);
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/SplitterDestinationTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/SplitterDestinationTests.cs
@@ -9,8 +9,8 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0xE0, Unsafe.SizeOf<SplitterDestinationVersion1>());
-            Assert.AreEqual(0x110, Unsafe.SizeOf<SplitterDestinationVersion2>());
+            Assert.That(0xE0, Is.EqualTo(Unsafe.SizeOf<SplitterDestinationVersion1>()));
+            Assert.That(0x110, Is.EqualTo(Unsafe.SizeOf<SplitterDestinationVersion2>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/SplitterStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/SplitterStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x20, Unsafe.SizeOf<SplitterState>());
+            Assert.That(0x20, Is.EqualTo(Unsafe.SizeOf<SplitterState>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/VoiceChannelResourceTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/VoiceChannelResourceTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0xD0, Unsafe.SizeOf<VoiceChannelResource>());
+            Assert.That(0xD0, Is.EqualTo(Unsafe.SizeOf<VoiceChannelResource>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/VoiceStateTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/VoiceStateTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.LessOrEqual(Unsafe.SizeOf<VoiceState>(), 0x220);
+            Assert.That(Unsafe.SizeOf<VoiceState>(), Is.LessThanOrEqualTo(0x220));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/Server/WaveBufferTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/Server/WaveBufferTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer.Server
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x58, Unsafe.SizeOf<WaveBuffer>());
+            Assert.That(0x58, Is.EqualTo(Unsafe.SizeOf<WaveBuffer>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/VoiceChannelResourceInParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/VoiceChannelResourceInParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x70, Unsafe.SizeOf<VoiceChannelResourceInParameter>());
+            Assert.That(0x70, Is.EqualTo(Unsafe.SizeOf<VoiceChannelResourceInParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/VoiceInParameterTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/VoiceInParameterTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x170, Unsafe.SizeOf<VoiceInParameter>());
+            Assert.That(0x170, Is.EqualTo(Unsafe.SizeOf<VoiceInParameter>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Audio/Renderer/VoiceOutStatusTests.cs
+++ b/src/Ryujinx.Tests/Audio/Renderer/VoiceOutStatusTests.cs
@@ -9,7 +9,7 @@ namespace Ryujinx.Tests.Audio.Renderer
         [Test]
         public void EnsureTypeSize()
         {
-            Assert.AreEqual(0x10, Unsafe.SizeOf<VoiceOutStatus>());
+            Assert.That(0x10, Is.EqualTo(Unsafe.SizeOf<VoiceOutStatus>()));
         }
     }
 }

--- a/src/Ryujinx.Tests/Common/Extensions/SequenceReaderExtensionsTests.cs
+++ b/src/Ryujinx.Tests/Common/Extensions/SequenceReaderExtensionsTests.cs
@@ -52,7 +52,7 @@ namespace Ryujinx.Tests.Common.Extensions
 
                 // Assert
                 MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), original, read);
-                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.Not.EqualTo(expected)), read, copy);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), read, copy);
             }
         }
 

--- a/src/Ryujinx.Tests/Common/Extensions/SequenceReaderExtensionsTests.cs
+++ b/src/Ryujinx.Tests/Common/Extensions/SequenceReaderExtensionsTests.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Tests.Common.Extensions
                 ref readonly MyUnmanagedStruct read = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out _);
 
                 // Assert
-                MyUnmanagedStruct.Assert(Assert.AreEqual, original, read);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), original, read);
             }
         }
 
@@ -51,8 +51,8 @@ namespace Ryujinx.Tests.Common.Extensions
                 ref readonly MyUnmanagedStruct read = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out var copy);
 
                 // Assert
-                MyUnmanagedStruct.Assert(Assert.AreEqual, original, read);
-                MyUnmanagedStruct.Assert(Assert.AreEqual, read, copy);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), original, read);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.Not.EqualTo(expected)), read, copy);
             }
         }
 
@@ -72,8 +72,8 @@ namespace Ryujinx.Tests.Common.Extensions
                 ref readonly MyUnmanagedStruct read = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out var copy);
 
                 // Assert
-                MyUnmanagedStruct.Assert(Assert.AreEqual, original, read);
-                MyUnmanagedStruct.Assert(Assert.AreNotEqual, read, copy);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), original, read);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.Not.EqualTo(expected)), read, copy);
             }
         }
 
@@ -112,7 +112,7 @@ namespace Ryujinx.Tests.Common.Extensions
             sequenceReader.ReadLittleEndian(out int roundTrippedValue);
 
             // Assert
-            Assert.AreEqual(TestValue, roundTrippedValue);
+            Assert.That(TestValue, Is.EqualTo(roundTrippedValue));
         }
 
         [Test]
@@ -131,7 +131,7 @@ namespace Ryujinx.Tests.Common.Extensions
             sequenceReader.ReadLittleEndian(out int roundTrippedValue);
 
             // Assert
-            Assert.AreNotEqual(TestValue, roundTrippedValue);
+            Assert.That(TestValue, Is.Not.EqualTo(roundTrippedValue));
         }
 
         [Test]
@@ -221,7 +221,7 @@ namespace Ryujinx.Tests.Common.Extensions
                 sequenceReader.ReadUnmanaged(out MyUnmanagedStruct read);
 
                 // Assert
-                MyUnmanagedStruct.Assert(Assert.AreEqual, original, read);
+                MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), original, read);
             }
         }
 
@@ -237,19 +237,19 @@ namespace Ryujinx.Tests.Common.Extensions
             static void SetConsumedAndAssert(scoped ref SequenceReader<byte> sequenceReader, long consumed)
             {
                 sequenceReader.SetConsumed(consumed);
-                Assert.AreEqual(consumed, sequenceReader.Consumed);
+                Assert.That(consumed, Is.EqualTo(sequenceReader.Consumed));
             }
 
             // Act/Assert
             ref readonly MyUnmanagedStruct struct0A = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out _);
 
-            Assert.AreEqual(sequenceReader.Consumed, MyUnmanagedStruct.SizeOf);
+            Assert.That(sequenceReader.Consumed, Is.EqualTo(MyUnmanagedStruct.SizeOf));
 
             SetConsumedAndAssert(ref sequenceReader, 0);
 
             ref readonly MyUnmanagedStruct struct0B = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out _);
-
-            MyUnmanagedStruct.Assert(Assert.AreEqual, struct0A, struct0B);
+            
+            MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), struct0A, struct0B);
 
             SetConsumedAndAssert(ref sequenceReader, 1);
 
@@ -260,8 +260,8 @@ namespace Ryujinx.Tests.Common.Extensions
             SetConsumedAndAssert(ref sequenceReader, MyUnmanagedStruct.SizeOf);
 
             ref readonly MyUnmanagedStruct struct1B = ref sequenceReader.GetRefOrRefToCopy<MyUnmanagedStruct>(out _);
-
-            MyUnmanagedStruct.Assert(Assert.AreEqual, struct1A, struct1B);
+            
+            MyUnmanagedStruct.Assert((expected, actual) => Assert.That(actual, Is.EqualTo(expected)), struct1A, struct1B);
         }
 
         [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
+++ b/src/Ryujinx.Tests/Cpu/EnvironmentTests.cs
@@ -43,7 +43,7 @@ namespace Ryujinx.Tests.Cpu
 
             // Subnormal results are not flushed to zero by default.
             // This operation should not be allowed to do constant propagation, hence the methods that explicitly disallow inlining.
-            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
+            Assert.That(GetDenormal() + GetZero(), Is.Not.EqualTo(0f));
 
             bool methodCalled = false;
             bool isFz = false;
@@ -56,11 +56,11 @@ namespace Ryujinx.Tests.Cpu
             int result = method(Marshal.GetFunctionPointerForDelegate(ManagedMethod));
 
             // Subnormal results are not flushed to zero by default, which we should have returned to exiting the method.
-            Assert.AreNotEqual(GetDenormal() + GetZero(), 0f);
+            Assert.That(GetDenormal() + GetZero(), Is.Not.EqualTo(0f));
 
-            Assert.True(result == 0);
-            Assert.True(methodCalled);
-            Assert.True(isFz);
+            Assert.That(result == 0, Is.True);
+            Assert.That(methodCalled, Is.True);
+            Assert.That(isFz, Is.True);
             return;
 
             void ManagedMethod()

--- a/src/Ryujinx.Tests/HLE/SoftwareKeyboardTests.cs
+++ b/src/Ryujinx.Tests/HLE/SoftwareKeyboardTests.cs
@@ -9,13 +9,13 @@ namespace Ryujinx.Tests.HLE
         [Test]
         public void StripUnicodeControlCodes_NullInput()
         {
-            Assert.IsNull(SoftwareKeyboardApplet.StripUnicodeControlCodes(null));
+            Assert.That(SoftwareKeyboardApplet.StripUnicodeControlCodes(null), Is.Null);
         }
 
         [Test]
         public void StripUnicodeControlCodes_EmptyInput()
         {
-            Assert.AreEqual(string.Empty, SoftwareKeyboardApplet.StripUnicodeControlCodes(string.Empty));
+            Assert.That(string.Empty, Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes(string.Empty)));
         }
 
         [Test]
@@ -34,14 +34,14 @@ namespace Ryujinx.Tests.HLE
 
             foreach (string prompt in prompts)
             {
-                Assert.AreEqual(prompt, SoftwareKeyboardApplet.StripUnicodeControlCodes(prompt));
+                Assert.That(prompt, Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes(prompt)));
             }
         }
 
         [Test]
         public void StripUnicodeControlCodes_StripsNewlines()
         {
-            Assert.AreEqual("I am very tall", SoftwareKeyboardApplet.StripUnicodeControlCodes("I \r\nam \r\nvery \r\ntall"));
+            Assert.That("I am very tall", Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes("I \r\nam \r\nvery \r\ntall")));
         }
 
         [Test]
@@ -49,14 +49,14 @@ namespace Ryujinx.Tests.HLE
         {
             // 0x13 is control code DC3 used by some games
             string specialInput = Encoding.UTF8.GetString(new byte[] { 0x13, 0x53, 0x68, 0x69, 0x6E, 0x65, 0x13 });
-            Assert.AreEqual("Shine", SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput));
+            Assert.That("Shine", Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput)));
         }
 
         [Test]
         public void StripUnicodeControlCodes_StripsToEmptyString()
         {
             string specialInput = Encoding.UTF8.GetString(new byte[] { 17, 18, 19, 20 }); // DC1 - DC4 special codes
-            Assert.AreEqual(string.Empty, SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput));
+            Assert.That(string.Empty, Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput)));
         }
 
         [Test]
@@ -64,7 +64,7 @@ namespace Ryujinx.Tests.HLE
         {
             // Turtles are a good example of multi-codepoint Unicode chars
             string specialInput = "♀ 🐢 🐢 ♂ ";
-            Assert.AreEqual(specialInput, SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput));
+            Assert.That(specialInput, Is.EqualTo(SoftwareKeyboardApplet.StripUnicodeControlCodes(specialInput)));
         }
     }
 }

--- a/src/Ryujinx.Tests/Memory/PartialUnmaps.cs
+++ b/src/Ryujinx.Tests/Memory/PartialUnmaps.cs
@@ -154,13 +154,13 @@ namespace Ryujinx.Tests.Memory
                 if (OperatingSystem.IsWindows())
                 {
                     // One thread should be present on the thread local map. Trimming should remove it.
-                    Assert.AreEqual(1, CountThreads(ref state));
+                    Assert.That(1, Is.EqualTo(CountThreads(ref state)));
                 }
 
                 shouldAccess = false;
                 testThread.Join();
 
-                Assert.False(error);
+                Assert.That(error, Is.False);
 
                 string test = null;
 
@@ -177,7 +177,7 @@ namespace Ryujinx.Tests.Memory
                 {
                     state.TrimThreads();
 
-                    Assert.AreEqual(0, CountThreads(ref state));
+                    Assert.That(0, Is.EqualTo(CountThreads(ref state)));
                 }
 
                 /*
@@ -267,7 +267,7 @@ namespace Ryujinx.Tests.Memory
                 writeLoopState.Running = 0;
                 testThread.Join();
 
-                Assert.False(writeLoopState.Error != 0);
+                Assert.That(writeLoopState.Error != 0, Is.False);
             }
             finally
             {
@@ -302,11 +302,11 @@ namespace Ryujinx.Tests.Memory
             testThread.Start();
             Thread.Sleep(200);
 
-            Assert.AreEqual(1, CountThreads(ref state));
+            Assert.That(1, Is.EqualTo(CountThreads(ref state)));
 
             // Trimming should not remove the thread as it's still active.
             state.TrimThreads();
-            Assert.AreEqual(1, CountThreads(ref state));
+            Assert.That(1, Is.EqualTo(CountThreads(ref state)));
 
             running = false;
 
@@ -314,7 +314,7 @@ namespace Ryujinx.Tests.Memory
 
             // Should trim now that it's inactive.
             state.TrimThreads();
-            Assert.AreEqual(0, CountThreads(ref state));
+            Assert.That(0, Is.EqualTo(CountThreads(ref state)));
         }
 
         [Test]
@@ -335,35 +335,35 @@ namespace Ryujinx.Tests.Memory
                 for (int i = 0; i < ThreadLocalMap<int>.MapSize; i++)
                 {
                     // Should obtain the index matching the call #.
-                    Assert.AreEqual(i, getOrReserve(i + 1, i));
+                    Assert.That(i, Is.EqualTo(getOrReserve(i + 1, i)));
 
                     // Check that this and all previously reserved thread IDs and struct contents are intact.
                     for (int j = 0; j <= i; j++)
                     {
-                        Assert.AreEqual(j + 1, state.LocalCounts.ThreadIds[j]);
-                        Assert.AreEqual(j, state.LocalCounts.Structs[j]);
+                        Assert.That(j + 1, Is.EqualTo(state.LocalCounts.ThreadIds[j]));
+                        Assert.That(j, Is.EqualTo(state.LocalCounts.Structs[j]));
                     }
                 }
 
                 // Trying to reserve again when the map is full should return -1.
-                Assert.AreEqual(-1, getOrReserve(200, 0));
+                Assert.That(-1, Is.EqualTo(getOrReserve(200, 0)));
 
                 for (int i = 0; i < ThreadLocalMap<int>.MapSize; i++)
                 {
                     // Should obtain the index matching the call #, as it already exists.
-                    Assert.AreEqual(i, getOrReserve(i + 1, -1));
+                    Assert.That(i, Is.EqualTo(getOrReserve(i + 1, -1)));
 
                     // The struct should not be reset to -1.
-                    Assert.AreEqual(i, state.LocalCounts.Structs[i]);
+                    Assert.That(i, Is.EqualTo(state.LocalCounts.Structs[i]));
                 }
 
                 // Clear one of the ids as if it were freed.
                 state.LocalCounts.ThreadIds[13] = 0;
 
                 // GetOrReserve should now obtain and return 13.
-                Assert.AreEqual(13, getOrReserve(300, 301));
-                Assert.AreEqual(300, state.LocalCounts.ThreadIds[13]);
-                Assert.AreEqual(301, state.LocalCounts.Structs[13]);
+                Assert.That(13, Is.EqualTo(getOrReserve(300, 301)));
+                Assert.That(300, Is.EqualTo(state.LocalCounts.ThreadIds[13]));
+                Assert.That(301, Is.EqualTo(state.LocalCounts.Structs[13]));
             }
         }
 
@@ -462,7 +462,7 @@ namespace Ryujinx.Tests.Memory
                 thread.Join();
             }
 
-            Assert.False(error);
+            Assert.That(error, Is.False);
         }
     }
 }

--- a/src/Ryujinx.Tests/Ryujinx.Tests.csproj
+++ b/src/Ryujinx.Tests/Ryujinx.Tests.csproj
@@ -18,33 +18,33 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="NUnit"/>
+    <PackageReference Include="NUnit3TestAdapter"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj" />
-    <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj" />
-    <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj" />
-    <ProjectReference Include="..\Ryujinx.Tests.Memory\Ryujinx.Tests.Memory.csproj" />
-    <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj" />
-    <ProjectReference Include="..\Ryujinx.Tests.Unicorn\Ryujinx.Tests.Unicorn.csproj" />
-    <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj" />
+    <ProjectReference Include="..\Ryujinx.Audio\Ryujinx.Audio.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Cpu\Ryujinx.Cpu.csproj"/>
+    <ProjectReference Include="..\Ryujinx.HLE\Ryujinx.HLE.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Tests.Memory\Ryujinx.Tests.Memory.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Memory\Ryujinx.Memory.csproj"/>
+    <ProjectReference Include="..\Ryujinx.Tests.Unicorn\Ryujinx.Tests.Unicorn.csproj"/>
+    <ProjectReference Include="..\ARMeilleure\ARMeilleure.csproj"/>
   </ItemGroup>
 
   <Target Name="CopyUnicorn" AfterTargets="Build">
     <ItemGroup>
-      <UnicornLib Include="..\Ryujinx.Tests.Unicorn\libs\$(TargetOS)\*unicorn.*" />
+      <UnicornLib Include="..\Ryujinx.Tests.Unicorn\libs\$(TargetOS)\*unicorn.*"/>
     </ItemGroup>
-    <Copy SourceFiles="@(UnicornLib)" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+    <Copy SourceFiles="@(UnicornLib)" DestinationFolder="$(OutputPath)" ContinueOnError="true"/>
   </Target>
 
   <Target Name="CleanUnicorn" BeforeTargets="Clean">
     <ItemGroup>
-      <UnicornLib Include="$(OutputPath)/unicorn.*" />
+      <UnicornLib Include="$(OutputPath)/unicorn.*"/>
     </ItemGroup>
-    <Delete Files="@(UnicornLib)" />
+    <Delete Files="@(UnicornLib)"/>
   </Target>
 
 </Project>

--- a/src/Ryujinx.Tests/Time/TimeZoneRuleTests.cs
+++ b/src/Ryujinx.Tests/Time/TimeZoneRuleTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Ryujinx.HLE.HOS.Services.Time.TimeZone;
 using System.Runtime.CompilerServices;
+using Is = NUnit.Framework.Is;
 
 namespace Ryujinx.Tests.Time
 {
@@ -11,7 +12,7 @@ namespace Ryujinx.Tests.Time
             [Test]
             public void EnsureTypeSize()
             {
-                Assert.AreEqual(0x4000, Unsafe.SizeOf<TimeZoneRule>());
+                Assert.That(0x4000, Is.EqualTo(Unsafe.SizeOf<TimeZoneRule>()));
             }
         }
     }

--- a/src/Ryujinx.Tests/TreeDictionaryTests.cs
+++ b/src/Ryujinx.Tests/TreeDictionaryTests.cs
@@ -12,7 +12,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.That(dictionary.Count, Is.EqualTo(0));
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -22,7 +22,7 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(11, 2);
             dictionary.Add(5, 2);
 
-            Assert.AreEqual(dictionary.Count, 7);
+            Assert.That(dictionary.Count, Is.EqualTo(7));
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
@@ -36,14 +36,14 @@ namespace Ryujinx.Tests.Collections
              *  
              */
 
-            Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 2);
-            Assert.AreEqual(list[1].Key, 1);
-            Assert.AreEqual(list[2].Key, 4);
-            Assert.AreEqual(list[3].Key, 3);
-            Assert.AreEqual(list[4].Key, 10);
-            Assert.AreEqual(list[5].Key, 5);
-            Assert.AreEqual(list[6].Key, 11);
+            Assert.That(list.Count, Is.EqualTo(dictionary.Count));
+            Assert.That(list[0].Key, Is.EqualTo(2));
+            Assert.That(list[1].Key, Is.EqualTo(1));
+            Assert.That(list[2].Key, Is.EqualTo(4));
+            Assert.That(list[3].Key, Is.EqualTo(3));
+            Assert.That(list[4].Key, Is.EqualTo(10));
+            Assert.That(list[5].Key, Is.EqualTo(5));
+            Assert.That(list[6].Key, Is.EqualTo(11));
         }
 
         [Test]
@@ -51,7 +51,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.That(dictionary.Count, Is.EqualTo(0));
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -66,7 +66,7 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(13, 2);
             dictionary.Add(24, 2);
             dictionary.Add(6, 2);
-            Assert.AreEqual(dictionary.Count, 13);
+            Assert.That(dictionary.Count, Is.EqualTo(13));
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
@@ -84,20 +84,20 @@ namespace Ryujinx.Tests.Collections
             {
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
-            Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.That(list.Count, Is.EqualTo(dictionary.Count));
+            Assert.That(list[0].Key, Is.EqualTo(4));
+            Assert.That(list[1].Key, Is.EqualTo(2));
+            Assert.That(list[2].Key, Is.EqualTo(10));
+            Assert.That(list[3].Key, Is.EqualTo(1));
+            Assert.That(list[4].Key, Is.EqualTo(3));
+            Assert.That(list[5].Key, Is.EqualTo(7));
+            Assert.That(list[6].Key, Is.EqualTo(13));
+            Assert.That(list[7].Key, Is.EqualTo(5));
+            Assert.That(list[8].Key, Is.EqualTo(9));
+            Assert.That(list[9].Key, Is.EqualTo(11));
+            Assert.That(list[10].Key, Is.EqualTo(24));
+            Assert.That(list[11].Key, Is.EqualTo(6));
+            Assert.That(list[12].Key, Is.EqualTo(8));
 
             list.Clear();
 
@@ -118,18 +118,18 @@ namespace Ryujinx.Tests.Collections
             {
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 6);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 8);
+            Assert.That(list[0].Key, Is.EqualTo(4));
+            Assert.That(list[1].Key, Is.EqualTo(2));
+            Assert.That(list[2].Key, Is.EqualTo(10));
+            Assert.That(list[3].Key, Is.EqualTo(1));
+            Assert.That(list[4].Key, Is.EqualTo(3));
+            Assert.That(list[5].Key, Is.EqualTo(6));
+            Assert.That(list[6].Key, Is.EqualTo(13));
+            Assert.That(list[7].Key, Is.EqualTo(5));
+            Assert.That(list[8].Key, Is.EqualTo(9));
+            Assert.That(list[9].Key, Is.EqualTo(11));
+            Assert.That(list[10].Key, Is.EqualTo(24));
+            Assert.That(list[11].Key, Is.EqualTo(8));
 
             list.Clear();
 
@@ -149,17 +149,17 @@ namespace Ryujinx.Tests.Collections
             {
                 Console.WriteLine($"{node.Key} -> {node.Value}");
             }
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 9);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 6);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 8);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
+            Assert.That(list[0].Key, Is.EqualTo(4));
+            Assert.That(list[1].Key, Is.EqualTo(2));
+            Assert.That(list[2].Key, Is.EqualTo(9));
+            Assert.That(list[3].Key, Is.EqualTo(1));
+            Assert.That(list[4].Key, Is.EqualTo(3));
+            Assert.That(list[5].Key, Is.EqualTo(6));
+            Assert.That(list[6].Key, Is.EqualTo(13));
+            Assert.That(list[7].Key, Is.EqualTo(5));
+            Assert.That(list[8].Key, Is.EqualTo(8));
+            Assert.That(list[9].Key, Is.EqualTo(11));
+            Assert.That(list[10].Key, Is.EqualTo(24));
         }
 
         [Test]
@@ -167,7 +167,7 @@ namespace Ryujinx.Tests.Collections
         {
             TreeDictionary<int, int> dictionary = new();
 
-            Assert.AreEqual(dictionary.Count, 0);
+            Assert.That(dictionary.Count, Is.EqualTo(0));
 
             dictionary.Add(2, 7);
             dictionary.Add(1, 4);
@@ -182,7 +182,7 @@ namespace Ryujinx.Tests.Collections
             dictionary.Add(13, 2);
             dictionary.Add(24, 2);
             dictionary.Add(6, 2);
-            Assert.AreEqual(dictionary.Count, 13);
+            Assert.That(dictionary.Count, Is.EqualTo(13));
 
             List<KeyValuePair<int, int>> list = dictionary.AsLevelOrderList();
 
@@ -201,44 +201,44 @@ namespace Ryujinx.Tests.Collections
              *                6  8 
              */
 
-            Assert.AreEqual(list.Count, dictionary.Count);
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.That(list.Count, Is.EqualTo(dictionary.Count));
+            Assert.That(list[0].Key, Is.EqualTo(4));
+            Assert.That(list[1].Key, Is.EqualTo(2));
+            Assert.That(list[2].Key, Is.EqualTo(10));
+            Assert.That(list[3].Key, Is.EqualTo(1));
+            Assert.That(list[4].Key, Is.EqualTo(3));
+            Assert.That(list[5].Key, Is.EqualTo(7));
+            Assert.That(list[6].Key, Is.EqualTo(13));
+            Assert.That(list[7].Key, Is.EqualTo(5));
+            Assert.That(list[8].Key, Is.EqualTo(9));
+            Assert.That(list[9].Key, Is.EqualTo(11));
+            Assert.That(list[10].Key, Is.EqualTo(24));
+            Assert.That(list[11].Key, Is.EqualTo(6));
+            Assert.That(list[12].Key, Is.EqualTo(8));
 
-            Assert.AreEqual(list[4].Value, 2);
+            Assert.That(list[4].Value, Is.EqualTo(2));
 
             dictionary.Add(3, 4);
 
             list = dictionary.AsLevelOrderList();
 
-            Assert.AreEqual(list[4].Value, 4);
+            Assert.That(list[4].Value, Is.EqualTo(4));
 
 
             // Assure that none of the nodes locations have been modified.
-            Assert.AreEqual(list[0].Key, 4);
-            Assert.AreEqual(list[1].Key, 2);
-            Assert.AreEqual(list[2].Key, 10);
-            Assert.AreEqual(list[3].Key, 1);
-            Assert.AreEqual(list[4].Key, 3);
-            Assert.AreEqual(list[5].Key, 7);
-            Assert.AreEqual(list[6].Key, 13);
-            Assert.AreEqual(list[7].Key, 5);
-            Assert.AreEqual(list[8].Key, 9);
-            Assert.AreEqual(list[9].Key, 11);
-            Assert.AreEqual(list[10].Key, 24);
-            Assert.AreEqual(list[11].Key, 6);
-            Assert.AreEqual(list[12].Key, 8);
+            Assert.That(list[0].Key, Is.EqualTo(4));
+            Assert.That(list[1].Key, Is.EqualTo(2));
+            Assert.That(list[2].Key, Is.EqualTo(10));
+            Assert.That(list[3].Key, Is.EqualTo(1));
+            Assert.That(list[4].Key, Is.EqualTo(3));
+            Assert.That(list[5].Key, Is.EqualTo(7));
+            Assert.That(list[6].Key, Is.EqualTo(13));
+            Assert.That(list[7].Key, Is.EqualTo(5));
+            Assert.That(list[8].Key, Is.EqualTo(9));
+            Assert.That(list[9].Key, Is.EqualTo(11));
+            Assert.That(list[10].Key, Is.EqualTo(24));
+            Assert.That(list[11].Key, Is.EqualTo(6));
+            Assert.That(list[12].Key, Is.EqualTo(8));
         }
     }
 }

--- a/src/Ryujinx.UI.Common/App/ApplicationData.cs
+++ b/src/Ryujinx.UI.Common/App/ApplicationData.cs
@@ -27,6 +27,8 @@ namespace Ryujinx.UI.App.Common
         public ulong Id { get; set; }
         public string Developer { get; set; } = "Unknown";
         public string Version { get; set; } = "0";
+        public int PlayerCount { get; set; }
+        public int GameCount { get; set; }
         public TimeSpan TimePlayed { get; set; }
         public DateTime? LastPlayed { get; set; }
         public string FileExtension { get; set; }
@@ -46,7 +48,8 @@ namespace Ryujinx.UI.App.Common
 
         [JsonIgnore] public string IdBaseString => IdBase.ToString("x16");
 
-        public static string GetBuildId(VirtualFileSystem virtualFileSystem, IntegrityCheckLevel checkLevel, string titleFilePath)
+        public static string GetBuildId(VirtualFileSystem virtualFileSystem, IntegrityCheckLevel checkLevel,
+            string titleFilePath)
         {
             using FileStream file = new(titleFilePath, FileMode.Open, FileAccess.Read);
 
@@ -110,7 +113,8 @@ namespace Ryujinx.UI.App.Common
 
             if (mainNca == null)
             {
-                Logger.Error?.Print(LogClass.Application, "Extraction failure. The main NCA was not present in the selected file");
+                Logger.Error?.Print(LogClass.Application,
+                    "Extraction failure. The main NCA was not present in the selected file");
 
                 return string.Empty;
             }
@@ -135,7 +139,8 @@ namespace Ryujinx.UI.App.Common
             {
                 if (patchNca.CanOpenSection(NcaSectionType.Code))
                 {
-                    codeFs = mainNca.OpenFileSystemWithPatch(patchNca, NcaSectionType.Code, IntegrityCheckLevel.ErrorOnInvalid);
+                    codeFs = mainNca.OpenFileSystemWithPatch(patchNca, NcaSectionType.Code,
+                        IntegrityCheckLevel.ErrorOnInvalid);
                 }
             }
 
@@ -162,7 +167,8 @@ namespace Ryujinx.UI.App.Common
             NsoReader reader = new();
             reader.Initialize(nsoFile.Release().AsStorage().AsFile(OpenMode.Read)).ThrowIfFailure();
 
-            return BitConverter.ToString(reader.Header.ModuleId.ItemsRo.ToArray()).Replace("-", string.Empty).ToUpper()[..16];
+            return BitConverter.ToString(reader.Header.ModuleId.ItemsRo.ToArray()).Replace("-", string.Empty)
+                .ToUpper()[..16];
         }
     }
 }

--- a/src/Ryujinx.UI.Common/App/LdnGameData.cs
+++ b/src/Ryujinx.UI.Common/App/LdnGameData.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+
+namespace Ryujinx.UI.App.Common
+{
+    public struct LdnGameData
+    {
+        public string Id { get; set; }
+        public int PlayerCount { get; set; }
+        public int MaxPlayerCount { get; set; }
+        public string GameName { get; set; }
+        public string TitleId { get; set; }
+        public string Mode { get; set; }
+        public string Status { get; set; }
+        public IEnumerable<string> Players { get; set; }
+    }
+}

--- a/src/Ryujinx.UI.Common/App/LdnGameDataReceivedEventArgs.cs
+++ b/src/Ryujinx.UI.Common/App/LdnGameDataReceivedEventArgs.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ryujinx.UI.App.Common
+{
+    public class LdnGameDataReceivedEventArgs : EventArgs
+    {
+        public IEnumerable<LdnGameData> LdnData { get; set; }
+    }
+}

--- a/src/Ryujinx.UI.Common/App/LdnGameDataSerializerContext.cs
+++ b/src/Ryujinx.UI.Common/App/LdnGameDataSerializerContext.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Ryujinx.UI.App.Common
+{
+    [JsonSerializable(typeof(IEnumerable<LdnGameData>))]
+    internal partial class LdnGameDataSerializerContext : JsonSerializerContext
+    {
+    }
+}

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationFileFormat.cs
@@ -393,6 +393,21 @@ namespace Ryujinx.UI.Common.Configuration
         public string MultiplayerLanInterfaceId { get; set; }
 
         /// <summary>
+        /// Disable P2p Toggle
+        /// </summary>
+        public bool MultiplayerDisableP2p { get; set; }
+
+        /// <summary>
+        /// Local network passphrase, for private networks.
+        /// </summary>
+        public string MultiplayerLdnPassphrase { get; set; }
+
+        /// <summary>
+        /// Custom LDN Server
+        /// </summary>
+        public string LdnServer { get; set; }
+
+        /// <summary>
         /// Uses Hypervisor over JIT if available
         /// </summary>
         public bool UseHypervisor { get; set; }
@@ -406,7 +421,8 @@ namespace Ryujinx.UI.Common.Configuration
         {
             try
             {
-                configurationFileFormat = JsonHelper.DeserializeFromFile(path, ConfigurationFileFormatSettings.SerializerContext.ConfigurationFileFormat);
+                configurationFileFormat = JsonHelper.DeserializeFromFile(path,
+                    ConfigurationFileFormatSettings.SerializerContext.ConfigurationFileFormat);
 
                 return configurationFileFormat.Version != 0;
             }
@@ -424,7 +440,8 @@ namespace Ryujinx.UI.Common.Configuration
         /// <param name="path">The path to the JSON configuration file</param>
         public void SaveConfig(string path)
         {
-            JsonHelper.SerializeToFile(path, this, ConfigurationFileFormatSettings.SerializerContext.ConfigurationFileFormat);
+            JsonHelper.SerializeToFile(path, this,
+                ConfigurationFileFormatSettings.SerializerContext.ConfigurationFileFormat);
         }
     }
 }

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Migration.cs
@@ -738,6 +738,9 @@ namespace Ryujinx.UI.Common.Configuration
 
             Multiplayer.LanInterfaceId.Value = configurationFileFormat.MultiplayerLanInterfaceId;
             Multiplayer.Mode.Value = configurationFileFormat.MultiplayerMode;
+            Multiplayer.DisableP2p.Value = configurationFileFormat.MultiplayerDisableP2p;
+            Multiplayer.LdnPassphrase.Value = configurationFileFormat.MultiplayerLdnPassphrase;
+            Multiplayer.LdnServer.Value = configurationFileFormat.LdnServer;
 
             if (configurationFileUpdated)
             {

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Model.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.Model.cs
@@ -24,6 +24,7 @@ namespace Ryujinx.UI.Common.Configuration
                 public ReactiveObject<bool> IconColumn { get; private set; }
                 public ReactiveObject<bool> AppColumn { get; private set; }
                 public ReactiveObject<bool> DevColumn { get; private set; }
+                public ReactiveObject<bool> LdnInfoColumn { get; private set; }
                 public ReactiveObject<bool> VersionColumn { get; private set; }
                 public ReactiveObject<bool> TimePlayedColumn { get; private set; }
                 public ReactiveObject<bool> LastPlayedColumn { get; private set; }
@@ -38,6 +39,7 @@ namespace Ryujinx.UI.Common.Configuration
                     AppColumn = new ReactiveObject<bool>();
                     DevColumn = new ReactiveObject<bool>();
                     VersionColumn = new ReactiveObject<bool>();
+                    LdnInfoColumn = new ReactiveObject<bool>();
                     TimePlayedColumn = new ReactiveObject<bool>();
                     LastPlayedColumn = new ReactiveObject<bool>();
                     FileExtColumn = new ReactiveObject<bool>();
@@ -571,11 +573,32 @@ namespace Ryujinx.UI.Common.Configuration
             /// </summary>
             public ReactiveObject<MultiplayerMode> Mode { get; private set; }
 
+            /// <summary>
+            /// Disable P2P
+            /// </summary>
+            public ReactiveObject<bool> DisableP2p { get; private set; }
+
+            /// <summary>
+            /// LDN PassPhrase
+            /// </summary>
+            public ReactiveObject<string> LdnPassphrase { get; private set; }
+
+            /// <summary>
+            /// LDN Server
+            /// </summary>
+            public ReactiveObject<string> LdnServer { get; private set; }
+
             public MultiplayerSection()
             {
                 LanInterfaceId = new ReactiveObject<string>();
                 Mode = new ReactiveObject<MultiplayerMode>();
                 Mode.LogChangesToValue(nameof(MultiplayerMode));
+                DisableP2p = new ReactiveObject<bool>();
+                DisableP2p.LogChangesToValue(nameof(DisableP2p));
+                LdnPassphrase = new ReactiveObject<string>();
+                LdnPassphrase.LogChangesToValue(nameof(LdnPassphrase));
+                LdnServer = new ReactiveObject<string>();
+                LdnServer.LogChangesToValue(nameof(LdnServer));
             }
         }
 

--- a/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
+++ b/src/Ryujinx.UI.Common/Configuration/ConfigurationState.cs
@@ -87,6 +87,7 @@ namespace Ryujinx.UI.Common.Configuration
                     AppColumn = UI.GuiColumns.AppColumn,
                     DevColumn = UI.GuiColumns.DevColumn,
                     VersionColumn = UI.GuiColumns.VersionColumn,
+                    LdnInfoColumn = UI.GuiColumns.LdnInfoColumn,
                     TimePlayedColumn = UI.GuiColumns.TimePlayedColumn,
                     LastPlayedColumn = UI.GuiColumns.LastPlayedColumn,
                     FileExtColumn = UI.GuiColumns.FileExtColumn,
@@ -136,6 +137,9 @@ namespace Ryujinx.UI.Common.Configuration
                 PreferredGpu = Graphics.PreferredGpu,
                 MultiplayerLanInterfaceId = Multiplayer.LanInterfaceId,
                 MultiplayerMode = Multiplayer.Mode,
+                MultiplayerDisableP2p = Multiplayer.DisableP2p,
+                MultiplayerLdnPassphrase = Multiplayer.LdnPassphrase,
+                LdnServer = Multiplayer.LdnServer,
             };
 
             return configurationFile;
@@ -195,6 +199,9 @@ namespace Ryujinx.UI.Common.Configuration
             System.UseHypervisor.Value = true;
             Multiplayer.LanInterfaceId.Value = "0";
             Multiplayer.Mode.Value = MultiplayerMode.Disabled;
+            Multiplayer.DisableP2p.Value = false;
+            Multiplayer.LdnPassphrase.Value = string.Empty;
+            Multiplayer.LdnServer.Value = string.Empty;
             UI.GuiColumns.FavColumn.Value = true;
             UI.GuiColumns.IconColumn.Value = true;
             UI.GuiColumns.AppColumn.Value = true;

--- a/src/Ryujinx.UI.Common/Configuration/UI/GuiColumns.cs
+++ b/src/Ryujinx.UI.Common/Configuration/UI/GuiColumns.cs
@@ -7,6 +7,7 @@ namespace Ryujinx.UI.Common.Configuration.UI
         public bool AppColumn { get; set; }
         public bool DevColumn { get; set; }
         public bool VersionColumn { get; set; }
+        public bool LdnInfoColumn { get; set; }
         public bool TimePlayedColumn { get; set; }
         public bool LastPlayedColumn { get; set; }
         public bool FileExtColumn { get; set; }

--- a/src/Ryujinx/AppHost.cs
+++ b/src/Ryujinx/AppHost.cs
@@ -99,8 +99,9 @@ namespace Ryujinx.Ava
             ForceChangeCursor
         };
 
-        private CursorStates _cursorState = !ConfigurationState.Instance.Hid.EnableMouse.Value ?
-            CursorStates.CursorIsVisible : CursorStates.CursorIsHidden;
+        private CursorStates _cursorState = !ConfigurationState.Instance.Hid.EnableMouse.Value
+            ? CursorStates.CursorIsVisible
+            : CursorStates.CursorIsHidden;
 
         private DateTime _lastShaderReset;
         private uint _displayCount;
@@ -207,6 +208,9 @@ namespace Ryujinx.Ava
             ConfigurationState.Instance.System.EnableInternetAccess.Event += UpdateEnableInternetAccessState;
             ConfigurationState.Instance.Multiplayer.LanInterfaceId.Event += UpdateLanInterfaceIdState;
             ConfigurationState.Instance.Multiplayer.Mode.Event += UpdateMultiplayerModeState;
+            ConfigurationState.Instance.Multiplayer.LdnPassphrase.Event += UpdateLdnPassphraseState;
+            ConfigurationState.Instance.Multiplayer.LdnServer.Event += UpdateLdnServerState;
+            ConfigurationState.Instance.Multiplayer.DisableP2p.Event += UpdateDisableP2pState;
 
             _gpuCancellationTokenSource = new CancellationTokenSource();
             _gpuDoneEvent = new ManualResetEvent(false);
@@ -240,10 +244,10 @@ namespace Ryujinx.Ava
                 }
 
                 _isCursorInRenderer = point.X >= bounds.X &&
-                    Math.Ceiling(point.X) <= (int)window.Bounds.Width &&
-                    point.Y >= windowYOffset &&
-                    point.Y <= windowYLimit &&
-                    !_viewModel.IsSubMenuOpen;
+                                      Math.Ceiling(point.X) <= (int)window.Bounds.Width &&
+                                      point.Y >= windowYOffset &&
+                                      point.Y <= windowYLimit &&
+                                      !_viewModel.IsSubMenuOpen;
 
                 _ignoreCursorState = false;
             }
@@ -267,9 +271,9 @@ namespace Ryujinx.Ava
                 }
 
                 _ignoreCursorState = (point.X == bounds.X ||
-                    Math.Ceiling(point.X) == (int)window.Bounds.Width) &&
-                    point.Y >= windowYOffset &&
-                    point.Y <= windowYLimit;
+                                      Math.Ceiling(point.X) == (int)window.Bounds.Width) &&
+                                     point.Y >= windowYOffset &&
+                                     point.Y <= windowYLimit;
             }
 
             _cursorState = CursorStates.ForceChangeCursor;
@@ -277,19 +281,22 @@ namespace Ryujinx.Ava
 
         private void UpdateScalingFilterLevel(object sender, ReactiveEventArgs<int> e)
         {
-            _renderer.Window?.SetScalingFilter((Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
+            _renderer.Window?.SetScalingFilter(
+                (Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
             _renderer.Window?.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
         }
 
         private void UpdateScalingFilter(object sender, ReactiveEventArgs<ScalingFilter> e)
         {
-            _renderer.Window?.SetScalingFilter((Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
+            _renderer.Window?.SetScalingFilter(
+                (Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
             _renderer.Window?.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
         }
 
         private void UpdateColorSpacePassthrough(object sender, ReactiveEventArgs<bool> e)
         {
-            _renderer.Window?.SetColorSpacePassthrough((bool)ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Value);
+            _renderer.Window?.SetColorSpacePassthrough((bool)ConfigurationState.Instance.Graphics
+                .EnableColorSpacePassthrough.Value);
         }
 
         private void ShowCursor()
@@ -347,12 +354,15 @@ namespace Ryujinx.Ava
                         string sanitizedApplicationName = FileSystemUtils.SanitizeFileName(applicationName);
                         DateTime currentTime = DateTime.Now;
 
-                        string filename = $"{sanitizedApplicationName}_{currentTime.Year}-{currentTime.Month:D2}-{currentTime.Day:D2}_{currentTime.Hour:D2}-{currentTime.Minute:D2}-{currentTime.Second:D2}.png";
+                        string filename =
+                            $"{sanitizedApplicationName}_{currentTime.Year}-{currentTime.Month:D2}-{currentTime.Day:D2}_{currentTime.Hour:D2}-{currentTime.Minute:D2}-{currentTime.Second:D2}.png";
 
                         string directory = AppDataManager.Mode switch
                         {
-                            AppDataManager.LaunchMode.Portable or AppDataManager.LaunchMode.Custom => Path.Combine(AppDataManager.BaseDirPath, "screenshots"),
-                            _ => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures), "Ryujinx"),
+                            AppDataManager.LaunchMode.Portable or AppDataManager.LaunchMode.Custom => Path.Combine(
+                                AppDataManager.BaseDirPath, "screenshots"),
+                            _ => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+                                "Ryujinx"),
                         };
 
                         string path = Path.Combine(directory, filename);
@@ -363,7 +373,9 @@ namespace Ryujinx.Ava
                         }
                         catch (Exception ex)
                         {
-                            Logger.Error?.Print(LogClass.Application, $"Failed to create directory at path {directory}. Error : {ex.GetType().Name}", "Screenshot");
+                            Logger.Error?.Print(LogClass.Application,
+                                $"Failed to create directory at path {directory}. Error : {ex.GetType().Name}",
+                                "Screenshot");
 
                             return;
                         }
@@ -394,7 +406,9 @@ namespace Ryujinx.Ava
             }
             else
             {
-                Logger.Error?.Print(LogClass.Application, $"Screenshot is empty. Size : {e.Data.Length} bytes. Resolution : {e.Width}x{e.Height}", "Screenshot");
+                Logger.Error?.Print(LogClass.Application,
+                    $"Screenshot is empty. Size : {e.Data.Length} bytes. Resolution : {e.Width}x{e.Height}",
+                    "Screenshot");
             }
         }
 
@@ -415,14 +429,16 @@ namespace Ryujinx.Ava
 
             DisplaySleep.Prevent();
 
-            NpadManager.Initialize(Device, ConfigurationState.Instance.Hid.InputConfig, ConfigurationState.Instance.Hid.EnableKeyboard, ConfigurationState.Instance.Hid.EnableMouse);
+            NpadManager.Initialize(Device, ConfigurationState.Instance.Hid.InputConfig,
+                ConfigurationState.Instance.Hid.EnableKeyboard, ConfigurationState.Instance.Hid.EnableMouse);
             TouchScreenManager.Initialize(Device);
 
             _viewModel.IsGameRunning = true;
 
             Dispatcher.UIThread.InvokeAsync(() =>
             {
-                _viewModel.Title = TitleHelper.ActiveApplicationTitle(Device.Processes.ActiveApplication, Program.Version);
+                _viewModel.Title =
+                    TitleHelper.ActiveApplicationTitle(Device.Processes.ActiveApplication, Program.Version);
             });
 
             _viewModel.SetUiProgressHandlers(Device);
@@ -489,6 +505,21 @@ namespace Ryujinx.Ava
         private void UpdateMultiplayerModeState(object sender, ReactiveEventArgs<MultiplayerMode> e)
         {
             Device.Configuration.MultiplayerMode = e.NewValue;
+        }
+
+        private void UpdateLdnPassphraseState(object sender, ReactiveEventArgs<string> e)
+        {
+            Device.Configuration.MultiplayerLdnPassphrase = e.NewValue;
+        }
+
+        private void UpdateLdnServerState(object sender, ReactiveEventArgs<string> e)
+        {
+            Device.Configuration.MultiplayerLdnServer = e.NewValue;
+        }
+
+        private void UpdateDisableP2pState(object sender, ReactiveEventArgs<bool> e)
+        {
+            Device.Configuration.MultiplayerDisableP2p = e.NewValue;
         }
 
         public void ToggleVSync()
@@ -607,14 +638,16 @@ namespace Ryujinx.Ava
             if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime)
             {
                 if (!SetupValidator.CanStartApplication(ContentManager, ApplicationPath, out UserError userError))
-                { 
-                    if (SetupValidator.CanFixStartApplication(ContentManager, ApplicationPath, userError, out firmwareVersion))
+                {
+                    if (SetupValidator.CanFixStartApplication(ContentManager, ApplicationPath, userError,
+                            out firmwareVersion))
                     {
                         if (userError is UserError.NoFirmware)
                         {
                             UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
-                                LocaleManager.Instance[LocaleKeys.DialogFirmwareNoFirmwareInstalledMessage], 
-                                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedMessage, firmwareVersion.VersionString),
+                                LocaleManager.Instance[LocaleKeys.DialogFirmwareNoFirmwareInstalledMessage],
+                                LocaleManager.Instance.UpdateAndGetDynamicValue(
+                                    LocaleKeys.DialogFirmwareInstallEmbeddedMessage, firmwareVersion.VersionString),
                                 LocaleManager.Instance[LocaleKeys.InputDialogYes],
                                 LocaleManager.Instance[LocaleKeys.InputDialogNo],
                                 string.Empty);
@@ -644,8 +677,11 @@ namespace Ryujinx.Ava
                             _viewModel.RefreshFirmwareStatus();
 
                             await ContentDialogHelper.CreateInfoDialog(
-                                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstalledMessage, firmwareVersion.VersionString),
-                                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage, firmwareVersion.VersionString),
+                                LocaleManager.Instance.UpdateAndGetDynamicValue(
+                                    LocaleKeys.DialogFirmwareInstalledMessage, firmwareVersion.VersionString),
+                                LocaleManager.Instance.UpdateAndGetDynamicValue(
+                                    LocaleKeys.DialogFirmwareInstallEmbeddedSuccessMessage,
+                                    firmwareVersion.VersionString),
                                 LocaleManager.Instance[LocaleKeys.InputDialogOk],
                                 string.Empty,
                                 LocaleManager.Instance[LocaleKeys.RyujinxInfo]);
@@ -765,7 +801,8 @@ namespace Ryujinx.Ava
                             }
                             catch (ArgumentOutOfRangeException)
                             {
-                                Logger.Error?.Print(LogClass.Application, "The specified file is not supported by Ryujinx.");
+                                Logger.Error?.Print(LogClass.Application,
+                                    "The specified file is not supported by Ryujinx.");
 
                                 Device.Dispose();
 
@@ -785,7 +822,8 @@ namespace Ryujinx.Ava
                 return false;
             }
 
-            ApplicationMetadata appMeta = ApplicationLibrary.LoadAndSaveMetaData(Device.Processes.ActiveApplication.ProgramIdText,
+            ApplicationMetadata appMeta = ApplicationLibrary.LoadAndSaveMetaData(
+                Device.Processes.ActiveApplication.ProgramIdText,
                 appMetadata => appMetadata.UpdatePreGame()
             );
 
@@ -808,7 +846,8 @@ namespace Ryujinx.Ava
             Device?.System.TogglePauseEmulation(true);
 
             _viewModel.IsPaused = true;
-            _viewModel.Title = TitleHelper.ActiveApplicationTitle(Device?.Processes.ActiveApplication, Program.Version, LocaleManager.Instance[LocaleKeys.Paused]);
+            _viewModel.Title = TitleHelper.ActiveApplicationTitle(Device?.Processes.ActiveApplication, Program.Version,
+                LocaleManager.Instance[LocaleKeys.Paused]);
             Logger.Info?.Print(LogClass.Emulation, "Emulation was paused");
         }
 
@@ -827,7 +866,8 @@ namespace Ryujinx.Ava
 
             BackendThreading threadingMode = ConfigurationState.Instance.Graphics.BackendThreading;
 
-            var isGALThreaded = threadingMode == BackendThreading.On || (threadingMode == BackendThreading.Auto && renderer.PreferThreading);
+            var isGALThreaded = threadingMode == BackendThreading.On ||
+                                (threadingMode == BackendThreading.Auto && renderer.PreferThreading);
             if (isGALThreaded)
             {
                 renderer = new ThreadedRenderer(renderer);
@@ -839,44 +879,45 @@ namespace Ryujinx.Ava
             var memoryConfiguration = ConfigurationState.Instance.System.DramSize.Value;
 
             Device = new HLE.Switch(new HLEConfiguration(
-                VirtualFileSystem,
-                _viewModel.LibHacHorizonManager,
-                ContentManager,
-                _accountManager,
-                _userChannelPersistence,
-                renderer,
-                InitializeAudio(),
-                memoryConfiguration,
-                _viewModel.UiHandler,
-                (SystemLanguage)ConfigurationState.Instance.System.Language.Value,
-                (RegionCode)ConfigurationState.Instance.System.Region.Value,
-                ConfigurationState.Instance.Graphics.EnableVsync,
-                ConfigurationState.Instance.System.EnableDockedMode,
-                ConfigurationState.Instance.System.EnablePtc,
-                ConfigurationState.Instance.System.EnableInternetAccess,
-                ConfigurationState.Instance.System.EnableFsIntegrityChecks ? IntegrityCheckLevel.ErrorOnInvalid : IntegrityCheckLevel.None,
-                ConfigurationState.Instance.System.FsGlobalAccessLogMode,
-                ConfigurationState.Instance.System.SystemTimeOffset,
-                ConfigurationState.Instance.System.TimeZone,
-                ConfigurationState.Instance.System.MemoryManagerMode,
-                ConfigurationState.Instance.System.IgnoreMissingServices,
-                ConfigurationState.Instance.Graphics.AspectRatio,
-                ConfigurationState.Instance.System.AudioVolume,
-                ConfigurationState.Instance.System.UseHypervisor,
-                ConfigurationState.Instance.Multiplayer.LanInterfaceId,
-                ConfigurationState.Instance.Multiplayer.Mode
-                )
-            );
+                    VirtualFileSystem,
+                    _viewModel.LibHacHorizonManager,
+                    ContentManager,
+                    _accountManager,
+                    _userChannelPersistence,
+                    renderer,
+                    InitializeAudio(),
+                    memoryConfiguration,
+                    _viewModel.UiHandler,
+                    (SystemLanguage)ConfigurationState.Instance.System.Language.Value,
+                    (RegionCode)ConfigurationState.Instance.System.Region.Value,
+                    ConfigurationState.Instance.Graphics.EnableVsync,
+                    ConfigurationState.Instance.System.EnableDockedMode,
+                    ConfigurationState.Instance.System.EnablePtc,
+                    ConfigurationState.Instance.System.EnableInternetAccess,
+                    ConfigurationState.Instance.System.EnableFsIntegrityChecks
+                        ? IntegrityCheckLevel.ErrorOnInvalid
+                        : IntegrityCheckLevel.None,
+                    ConfigurationState.Instance.System.FsGlobalAccessLogMode,
+                    ConfigurationState.Instance.System.SystemTimeOffset,
+                    ConfigurationState.Instance.System.TimeZone,
+                    ConfigurationState.Instance.System.MemoryManagerMode,
+                    ConfigurationState.Instance.System.IgnoreMissingServices,
+                    ConfigurationState.Instance.Graphics.AspectRatio,
+                    ConfigurationState.Instance.System.AudioVolume,
+                    ConfigurationState.Instance.System.UseHypervisor,
+                    ConfigurationState.Instance.Multiplayer.LanInterfaceId.Value,
+                    ConfigurationState.Instance.Multiplayer.Mode,
+                    ConfigurationState.Instance.Multiplayer.DisableP2p,
+                    ConfigurationState.Instance.Multiplayer.LdnPassphrase,
+                    ConfigurationState.Instance.Multiplayer.LdnServer)
+                );
         }
 
         private static IHardwareDeviceDriver InitializeAudio()
         {
             var availableBackends = new List<AudioBackend>
             {
-                AudioBackend.SDL2,
-                AudioBackend.SoundIo,
-                AudioBackend.OpenAl,
-                AudioBackend.Dummy,
+                AudioBackend.SDL2, AudioBackend.SoundIo, AudioBackend.OpenAl, AudioBackend.Dummy,
             };
 
             AudioBackend preferredBackend = ConfigurationState.Instance.System.AudioBackend.Value;
@@ -891,7 +932,8 @@ namespace Ryujinx.Ava
                 }
             }
 
-            static IHardwareDeviceDriver InitializeAudioBackend<T>(AudioBackend backend, AudioBackend nextBackend) where T : IHardwareDeviceDriver, new()
+            static IHardwareDeviceDriver InitializeAudioBackend<T>(AudioBackend backend, AudioBackend nextBackend)
+                where T : IHardwareDeviceDriver, new()
             {
                 if (T.IsSupported)
                 {
@@ -908,13 +950,17 @@ namespace Ryujinx.Ava
             for (int i = 0; i < availableBackends.Count; i++)
             {
                 AudioBackend currentBackend = availableBackends[i];
-                AudioBackend nextBackend = i + 1 < availableBackends.Count ? availableBackends[i + 1] : AudioBackend.Dummy;
+                AudioBackend nextBackend =
+                    i + 1 < availableBackends.Count ? availableBackends[i + 1] : AudioBackend.Dummy;
 
                 deviceDriver = currentBackend switch
                 {
-                    AudioBackend.SDL2 => InitializeAudioBackend<SDL2HardwareDeviceDriver>(AudioBackend.SDL2, nextBackend),
-                    AudioBackend.SoundIo => InitializeAudioBackend<SoundIoHardwareDeviceDriver>(AudioBackend.SoundIo, nextBackend),
-                    AudioBackend.OpenAl => InitializeAudioBackend<OpenALHardwareDeviceDriver>(AudioBackend.OpenAl, nextBackend),
+                    AudioBackend.SDL2 => InitializeAudioBackend<SDL2HardwareDeviceDriver>(AudioBackend.SDL2,
+                        nextBackend),
+                    AudioBackend.SoundIo => InitializeAudioBackend<SoundIoHardwareDeviceDriver>(AudioBackend.SoundIo,
+                        nextBackend),
+                    AudioBackend.OpenAl => InitializeAudioBackend<OpenALHardwareDeviceDriver>(AudioBackend.OpenAl,
+                        nextBackend),
                     _ => new DummyHardwareDeviceDriver(),
                 };
 
@@ -970,10 +1016,13 @@ namespace Ryujinx.Ava
 
             Device.Gpu.Renderer.Initialize(_glLogLevel);
 
-            _renderer?.Window?.SetAntiAliasing((Graphics.GAL.AntiAliasing)ConfigurationState.Instance.Graphics.AntiAliasing.Value);
-            _renderer?.Window?.SetScalingFilter((Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
+            _renderer?.Window?.SetAntiAliasing(
+                (Graphics.GAL.AntiAliasing)ConfigurationState.Instance.Graphics.AntiAliasing.Value);
+            _renderer?.Window?.SetScalingFilter(
+                (Graphics.GAL.ScalingFilter)ConfigurationState.Instance.Graphics.ScalingFilter.Value);
             _renderer?.Window?.SetScalingFilterLevel(ConfigurationState.Instance.Graphics.ScalingFilterLevel.Value);
-            _renderer?.Window?.SetColorSpacePassthrough(ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough.Value);
+            _renderer?.Window?.SetColorSpacePassthrough(ConfigurationState.Instance.Graphics.EnableColorSpacePassthrough
+                .Value);
 
             Width = (int)RendererHost.Bounds.Width;
             Height = (int)RendererHost.Bounds.Height;
@@ -1047,10 +1096,12 @@ namespace Ryujinx.Ava
         public void UpdateStatus()
         {
             // Run a status update only when a frame is to be drawn. This prevents from updating the ui and wasting a render when no frame is queued.
-            string dockedMode = ConfigurationState.Instance.System.EnableDockedMode ? LocaleManager.Instance[LocaleKeys.Docked] : LocaleManager.Instance[LocaleKeys.Handheld];
+            string dockedMode = ConfigurationState.Instance.System.EnableDockedMode
+                ? LocaleManager.Instance[LocaleKeys.Docked]
+                : LocaleManager.Instance[LocaleKeys.Handheld];
 
             UpdateShaderCount();
-            
+
             if (GraphicsConfig.ResScale != 1)
             {
                 dockedMode += $" ({GraphicsConfig.ResScale}x)";
@@ -1061,7 +1112,8 @@ namespace Ryujinx.Ava
                 LocaleManager.Instance[LocaleKeys.VolumeShort] + $": {(int)(Device.GetVolume() * 100)}%",
                 dockedMode,
                 ConfigurationState.Instance.Graphics.AspectRatio.Value.ToText(),
-                LocaleManager.Instance[LocaleKeys.Game] + $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
+                LocaleManager.Instance[LocaleKeys.Game] +
+                $": {Device.Statistics.GetGameFrameRate():00.00} FPS ({Device.Statistics.GetGameFrameTime():00.00} ms)",
                 $"FIFO: {Device.Statistics.GetFifoPercent():00.00} %",
                 _displayCount));
         }
@@ -1129,8 +1181,9 @@ namespace Ryujinx.Ava
                     else
                     {
                         isCursorVisible = ConfigurationState.Instance.HideCursor.Value == HideCursorMode.Never ||
-                            (ConfigurationState.Instance.HideCursor.Value == HideCursorMode.OnIdle &&
-                            Stopwatch.GetTimestamp() - _lastCursorMoveTime < CursorHideIdleTime * Stopwatch.Frequency);
+                                          (ConfigurationState.Instance.HideCursor.Value == HideCursorMode.OnIdle &&
+                                           Stopwatch.GetTimestamp() - _lastCursorMoveTime <
+                                           CursorHideIdleTime * Stopwatch.Frequency);
                     }
                 }
 
@@ -1148,7 +1201,8 @@ namespace Ryujinx.Ava
 
                 Dispatcher.UIThread.Post(() =>
                 {
-                    if (_keyboardInterface.GetKeyboardStateSnapshot().IsPressed(Key.Delete) && _viewModel.WindowState is not WindowState.FullScreen)
+                    if (_keyboardInterface.GetKeyboardStateSnapshot().IsPressed(Key.Delete) &&
+                        _viewModel.WindowState is not WindowState.FullScreen)
                     {
                         Device.Processes.ActiveApplication.DiskCacheLoadState?.Cancel();
                     }
@@ -1178,6 +1232,7 @@ namespace Ryujinx.Ava
                             {
                                 Pause();
                             }
+
                             break;
                         case KeyboardHotkeyState.ToggleMute:
                             if (Device.IsAudioMuted())
@@ -1197,7 +1252,7 @@ namespace Ryujinx.Ava
                             break;
                         case KeyboardHotkeyState.ResScaleDown:
                             GraphicsConfig.ResScale =
-                            (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
+                                (MaxResolutionScale + GraphicsConfig.ResScale - 2) % MaxResolutionScale + 1;
                             break;
                         case KeyboardHotkeyState.VolumeUp:
                             _newVolume = MathF.Round((Device.GetVolume() + VolumeDelta), 2);
@@ -1231,7 +1286,9 @@ namespace Ryujinx.Ava
 
             if (_viewModel.IsActive && !ConfigurationState.Instance.Hid.EnableMouse.Value)
             {
-                hasTouch = TouchScreenManager.Update(true, (_inputManager.MouseDriver as AvaloniaMouseDriver).IsButtonPressed(MouseButton.Button1), ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
+                hasTouch = TouchScreenManager.Update(true,
+                    (_inputManager.MouseDriver as AvaloniaMouseDriver).IsButtonPressed(MouseButton.Button1),
+                    ConfigurationState.Instance.Graphics.AspectRatio.Value.ToFloat());
             }
 
             if (!hasTouch)

--- a/src/Ryujinx/Assets/Locales/en_US.json
+++ b/src/Ryujinx/Assets/Locales/en_US.json
@@ -847,5 +847,17 @@
   "MultiplayerMode": "Mode:",
   "MultiplayerModeTooltip": "Change LDN multiplayer mode.\n\nLdnMitm will modify local wireless/local play functionality in games to function as if it were LAN, allowing for local, same-network connections with other Ryujinx instances and hacked Nintendo Switch consoles that have the ldn_mitm module installed.\n\nMultiplayer requires all players to be on the same game version (i.e. Super Smash Bros. Ultimate v13.0.1 can't connect to v13.0.0).\n\nLeave DISABLED if unsure.",
   "MultiplayerModeDisabled": "Disabled",
-  "MultiplayerModeLdnMitm": "ldn_mitm"
+  "MultiplayerModeLdnMitm": "ldn_mitm",
+  "MultiplayerModeLdnRyu": "RyuLDN",
+  "MultiplayerDisableP2P": "Disable P2P Network Hosting (may increase latency)",
+  "MultiplayerDisableP2PTooltip": "Disable P2P network hosting, peers will proxy through the master server instead of connecting to you directly.",
+  "LdnPassphrase": "Network Passphrase:",
+  "LdnPassphraseTooltip": "You will only be able to see hosted games with the same passphrase as you.",
+  "LdnPassphraseInputTooltip": "Enter a passphrase in the format Ryujinx-<8 hex chars>. You will only be able to see hosted games with the same passphrase as you.",
+  "LdnPassphraseInputPublic": "(public)",
+  "GenLdnPass": "Generate Random",
+  "GenLdnPassTooltip": "Generates a new passphrase, which can be shared with other players.",
+  "ClearLdnPass": "Clear",
+  "ClearLdnPassTooltip": "Clears the current passphrase, returning to the public network.",
+  "InvalidLdnPassphrase": "Invalid Passphrase! Must be in the format \"Ryujinx-<8 hex chars>\""
 }

--- a/src/Ryujinx/Common/LocaleManager.cs
+++ b/src/Ryujinx/Common/LocaleManager.cs
@@ -32,8 +32,9 @@ namespace Ryujinx.Ava.Common.Locale
 
         private void Load()
         {
-            var localeLanguageCode = !string.IsNullOrEmpty(ConfigurationState.Instance.UI.LanguageCode.Value) ?
-                ConfigurationState.Instance.UI.LanguageCode.Value : CultureInfo.CurrentCulture.Name.Replace('-', '_');
+            var localeLanguageCode = !string.IsNullOrEmpty(ConfigurationState.Instance.UI.LanguageCode.Value)
+                ? ConfigurationState.Instance.UI.LanguageCode.Value
+                : CultureInfo.CurrentCulture.Name.Replace('-', '_');
 
             // Load en_US as default, if the target language translation is missing or incomplete.
             LoadDefaultLanguage();
@@ -99,7 +100,7 @@ namespace Ryujinx.Ava.Common.Locale
                 _ => false
             };
 
-        public static string FormatDynamicValue(LocaleKeys key, params object[] values) 
+        public static string FormatDynamicValue(LocaleKeys key, params object[] values)
             => Instance.UpdateAndGetDynamicValue(key, values);
 
         public string UpdateAndGetDynamicValue(LocaleKeys key, params object[] values)

--- a/src/Ryujinx/Program.cs
+++ b/src/Ryujinx/Program.cs
@@ -38,17 +38,20 @@ namespace Ryujinx.Ava
         public static bool UseHardwareAcceleration { get; private set; }
 
         [LibraryImport("user32.dll", SetLastError = true)]
-        public static partial int MessageBoxA(nint hWnd, [MarshalAs(UnmanagedType.LPStr)] string text, [MarshalAs(UnmanagedType.LPStr)] string caption, uint type);
+        public static partial int MessageBoxA(nint hWnd, [MarshalAs(UnmanagedType.LPStr)] string text,
+            [MarshalAs(UnmanagedType.LPStr)] string caption, uint type);
 
         private const uint MbIconwarning = 0x30;
 
         public static int Main(string[] args)
         {
             Version = ReleaseInformation.Version;
-            
+
             if (OperatingSystem.IsWindows() && !OperatingSystem.IsWindowsVersionAtLeast(10, 0, 17134))
             {
-                _ = MessageBoxA(nint.Zero, "You are running an outdated version of Windows.\n\nRyujinx supports Windows 10 version 1803 and newer.\n", $"Ryujinx {Version}", MbIconwarning);
+                _ = MessageBoxA(nint.Zero,
+                    "You are running an outdated version of Windows.\n\nRyujinx supports Windows 10 version 1803 and newer.\n",
+                    $"Ryujinx {Version}", MbIconwarning);
             }
 
             PreviewerDetached = true;
@@ -103,7 +106,7 @@ namespace Ryujinx.Ava
             Console.Title = $"{App.FullAppName} Console {Version}";
 
             // Hook unhandled exception and process exit events.
-            AppDomain.CurrentDomain.UnhandledException += (sender, e) 
+            AppDomain.CurrentDomain.UnhandledException += (sender, e)
                 => ProcessUnhandledException(sender, e.ExceptionObject as Exception, e.IsTerminating);
             AppDomain.CurrentDomain.ProcessExit += (_, _) => Exit();
 
@@ -123,7 +126,8 @@ namespace Ryujinx.Ava
             DiscordIntegrationModule.Initialize();
 
             // Initialize SDL2 driver
-            SDL2Driver.MainThreadDispatcher = action => Dispatcher.UIThread.InvokeAsync(action, DispatcherPriority.Input);
+            SDL2Driver.MainThreadDispatcher =
+                action => Dispatcher.UIThread.InvokeAsync(action, DispatcherPriority.Input);
 
             ReloadConfig();
 
@@ -133,12 +137,14 @@ namespace Ryujinx.Ava
             PrintSystemInfo();
 
             // Enable OGL multithreading on the driver, and some other flags.
-            DriverUtilities.InitDriverConfig(ConfigurationState.Instance.Graphics.BackendThreading == BackendThreading.Off);
+            DriverUtilities.InitDriverConfig(ConfigurationState.Instance.Graphics.BackendThreading ==
+                                             BackendThreading.Off);
 
             // Check if keys exists.
             if (!File.Exists(Path.Combine(AppDataManager.KeysDirPath, "prod.keys")))
             {
-                if (!(AppDataManager.Mode == AppDataManager.LaunchMode.UserProfile && File.Exists(Path.Combine(AppDataManager.KeysDirPathUser, "prod.keys"))))
+                if (!(AppDataManager.Mode == AppDataManager.LaunchMode.UserProfile &&
+                      File.Exists(Path.Combine(AppDataManager.KeysDirPathUser, "prod.keys"))))
                 {
                     MainWindow.ShowKeyErrorOnLoad = true;
                 }
@@ -146,13 +152,15 @@ namespace Ryujinx.Ava
 
             if (CommandLineState.LaunchPathArg != null)
             {
-                MainWindow.DeferLoadApplication(CommandLineState.LaunchPathArg, CommandLineState.LaunchApplicationId, CommandLineState.StartFullscreenArg);
+                MainWindow.DeferLoadApplication(CommandLineState.LaunchPathArg, CommandLineState.LaunchApplicationId,
+                    CommandLineState.StartFullscreenArg);
             }
         }
 
         public static void ReloadConfig()
         {
-            string localConfigurationPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ReleaseInformation.ConfigName);
+            string localConfigurationPath =
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ReleaseInformation.ConfigName);
             string appDataConfigurationPath = Path.Combine(AppDataManager.BaseDirPath, ReleaseInformation.ConfigName);
 
             // Now load the configuration as the other subsystems are now registered
@@ -169,7 +177,8 @@ namespace Ryujinx.Ava
             {
                 // No configuration, we load the default values and save it to disk
                 ConfigurationPath = appDataConfigurationPath;
-                Logger.Notice.Print(LogClass.Application, $"No configuration file found. Saving default configuration to: {ConfigurationPath}");
+                Logger.Notice.Print(LogClass.Application,
+                    $"No configuration file found. Saving default configuration to: {ConfigurationPath}");
 
                 ConfigurationState.Instance.LoadDefault();
                 ConfigurationState.Instance.ToFileFormat().SaveConfig(ConfigurationPath);
@@ -178,13 +187,15 @@ namespace Ryujinx.Ava
             {
                 Logger.Notice.Print(LogClass.Application, $"Loading configuration from: {ConfigurationPath}");
 
-                if (ConfigurationFileFormat.TryLoad(ConfigurationPath, out ConfigurationFileFormat configurationFileFormat))
+                if (ConfigurationFileFormat.TryLoad(ConfigurationPath,
+                        out ConfigurationFileFormat configurationFileFormat))
                 {
                     ConfigurationState.Instance.Load(configurationFileFormat, ConfigurationPath);
                 }
                 else
                 {
-                    Logger.Warning?.PrintMsg(LogClass.Application, $"Failed to load config! Loading the default config instead.\nFailed config location: {ConfigurationPath}");
+                    Logger.Warning?.PrintMsg(LogClass.Application,
+                        $"Failed to load config! Loading the default config instead.\nFailed config location: {ConfigurationPath}");
 
                     ConfigurationState.Instance.LoadDefault();
                 }
@@ -194,12 +205,13 @@ namespace Ryujinx.Ava
 
             // Check if graphics backend was overridden
             if (CommandLineState.OverrideGraphicsBackend is not null)
-                ConfigurationState.Instance.Graphics.GraphicsBackend.Value = CommandLineState.OverrideGraphicsBackend.ToLower() switch
-                {
-                    "opengl" => GraphicsBackend.OpenGl,
-                    "vulkan" => GraphicsBackend.Vulkan,
-                    _ => ConfigurationState.Instance.Graphics.GraphicsBackend
-                };
+                ConfigurationState.Instance.Graphics.GraphicsBackend.Value =
+                    CommandLineState.OverrideGraphicsBackend.ToLower() switch
+                    {
+                        "opengl" => GraphicsBackend.OpenGl,
+                        "vulkan" => GraphicsBackend.Vulkan,
+                        _ => ConfigurationState.Instance.Graphics.GraphicsBackend
+                    };
 
             // Check if docked mode was overriden.
             if (CommandLineState.OverrideDockedMode.HasValue)
@@ -245,13 +257,13 @@ namespace Ryujinx.Ava
         {
             Logger.Log log = Logger.Error ?? Logger.Notice;
             string message = $"Unhandled exception caught: {ex}";
-            
+
             // ReSharper disable once ConstantConditionalAccessQualifier
-            if (sender?.GetType()?.AsPrettyString() is {} senderName)
+            if (sender?.GetType()?.AsPrettyString() is { } senderName)
                 log.Print(LogClass.Application, message, senderName);
             else
                 log.PrintMsg(LogClass.Application, message);
-            
+
             if (isTerminating)
                 Exit();
         }

--- a/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
+++ b/src/Ryujinx/UI/Applet/AvaHostUIHandler.cs
@@ -31,7 +31,7 @@ namespace Ryujinx.Ava.UI.Applet
         public bool DisplayMessageDialog(ControllerAppletUIArgs args)
         {
             ManualResetEvent dialogCloseEvent = new(false);
-            
+
             bool okPressed = false;
 
             if (ConfigurationState.Instance.IgnoreApplet)
@@ -68,31 +68,32 @@ namespace Ryujinx.Ava.UI.Applet
                     bool opened = false;
 
                     UserResult response = await ContentDialogHelper.ShowDeferredContentDialog(_parent,
-                       title,
-                       message,
-                       string.Empty,
-                       LocaleManager.Instance[LocaleKeys.DialogOpenSettingsWindowLabel],
-                       string.Empty,
-                       LocaleManager.Instance[LocaleKeys.SettingsButtonClose],
-                       (int)Symbol.Important,
-                       deferEvent,
-                       async window =>
-                       {
-                           if (opened)
-                           {
-                               return;
-                           }
+                        title,
+                        message,
+                        string.Empty,
+                        LocaleManager.Instance[LocaleKeys.DialogOpenSettingsWindowLabel],
+                        string.Empty,
+                        LocaleManager.Instance[LocaleKeys.SettingsButtonClose],
+                        (int)Symbol.Important,
+                        deferEvent,
+                        async window =>
+                        {
+                            if (opened)
+                            {
+                                return;
+                            }
 
-                           opened = true;
+                            opened = true;
 
-                           _parent.SettingsWindow = new SettingsWindow(_parent.VirtualFileSystem, _parent.ContentManager);
+                            _parent.SettingsWindow =
+                                new SettingsWindow(_parent.VirtualFileSystem, _parent.ContentManager);
 
-                           await _parent.SettingsWindow.ShowDialog(window);
+                            await _parent.SettingsWindow.ShowDialog(window);
 
-                           _parent.SettingsWindow = null;
+                            _parent.SettingsWindow = null;
 
-                           opened = false;
-                       });
+                            opened = false;
+                        });
 
                     if (response == UserResult.Ok)
                     {
@@ -103,7 +104,9 @@ namespace Ryujinx.Ava.UI.Applet
                 }
                 catch (Exception ex)
                 {
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogMessageDialogErrorExceptionMessage, ex));
+                    await ContentDialogHelper.CreateErrorDialog(
+                        LocaleManager.Instance.UpdateAndGetDynamicValue(
+                            LocaleKeys.DialogMessageDialogErrorExceptionMessage, ex));
 
                     dialogCloseEvent.Set();
                 }
@@ -127,7 +130,9 @@ namespace Ryujinx.Ava.UI.Applet
                 try
                 {
                     _parent.ViewModel.AppHost.NpadManager.BlockInputUpdates();
-                    var response = await SwkbdAppletDialog.ShowInputDialog(LocaleManager.Instance[LocaleKeys.SoftwareKeyboard], args);
+                    var response =
+                        await SwkbdAppletDialog.ShowInputDialog(LocaleManager.Instance[LocaleKeys.SoftwareKeyboard],
+                            args);
 
                     if (response.Result == UserResult.Ok)
                     {
@@ -139,7 +144,9 @@ namespace Ryujinx.Ava.UI.Applet
                 {
                     error = true;
 
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage, ex));
+                    await ContentDialogHelper.CreateErrorDialog(
+                        LocaleManager.Instance.UpdateAndGetDynamicValue(
+                            LocaleKeys.DialogSoftwareKeyboardErrorExceptionMessage, ex));
                 }
                 finally
                 {
@@ -173,9 +180,7 @@ namespace Ryujinx.Ava.UI.Applet
                 {
                     ErrorAppletWindow msgDialog = new(_parent, buttons, message)
                     {
-                        Title = title,
-                        WindowStartupLocation = WindowStartupLocation.CenterScreen,
-                        Width = 400
+                        Title = title, WindowStartupLocation = WindowStartupLocation.CenterScreen, Width = 400
                     };
 
                     object response = await msgDialog.Run();
@@ -193,7 +198,9 @@ namespace Ryujinx.Ava.UI.Applet
                 {
                     dialogCloseEvent.Set();
 
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogErrorAppletErrorExceptionMessage, ex));
+                    await ContentDialogHelper.CreateErrorDialog(
+                        LocaleManager.Instance.UpdateAndGetDynamicValue(
+                            LocaleKeys.DialogErrorAppletErrorExceptionMessage, ex));
                 }
             });
 

--- a/src/Ryujinx/UI/Applet/AvaloniaDynamicTextInputHandler.cs
+++ b/src/Ryujinx/UI/Applet/AvaloniaDynamicTextInputHandler.cs
@@ -24,7 +24,7 @@ namespace Ryujinx.Ava.UI.Applet
         public AvaloniaDynamicTextInputHandler(MainWindow parent)
         {
             _parent = parent;
-            
+
             if (_parent.InputManager.KeyboardDriver is AvaloniaKeyboardDriver avaloniaKeyboardDriver)
             {
                 avaloniaKeyboardDriver.KeyPressed += AvaloniaDynamicTextInputHandler_KeyPressed;
@@ -37,19 +37,23 @@ namespace Ryujinx.Ava.UI.Applet
             Dispatcher.UIThread.Post(() =>
             {
                 _textChangedSubscription = _hiddenTextBox.GetObservable(TextBox.TextProperty).Subscribe(TextChanged);
-                _selectionStartChangedSubscription = _hiddenTextBox.GetObservable(TextBox.SelectionStartProperty).Subscribe(SelectionChanged);
-                _selectionEndtextChangedSubscription = _hiddenTextBox.GetObservable(TextBox.SelectionEndProperty).Subscribe(SelectionChanged);
+                _selectionStartChangedSubscription = _hiddenTextBox.GetObservable(TextBox.SelectionStartProperty)
+                    .Subscribe(SelectionChanged);
+                _selectionEndtextChangedSubscription = _hiddenTextBox.GetObservable(TextBox.SelectionEndProperty)
+                    .Subscribe(SelectionChanged);
             });
         }
 
         private void TextChanged(string text)
         {
-            TextChangedEvent?.Invoke(text ?? string.Empty, _hiddenTextBox.SelectionStart, _hiddenTextBox.SelectionEnd, false);
+            TextChangedEvent?.Invoke(text ?? string.Empty, _hiddenTextBox.SelectionStart, _hiddenTextBox.SelectionEnd,
+                false);
         }
 
         private void SelectionChanged(int _)
         {
-            TextChangedEvent?.Invoke(_hiddenTextBox.Text ?? string.Empty, _hiddenTextBox.SelectionStart, _hiddenTextBox.SelectionEnd, false);
+            TextChangedEvent?.Invoke(_hiddenTextBox.Text ?? string.Empty, _hiddenTextBox.SelectionStart,
+                _hiddenTextBox.SelectionEnd, false);
         }
 
         private void AvaloniaDynamicTextInputHandler_TextInput(object sender, string text)
@@ -121,7 +125,7 @@ namespace Ryujinx.Ava.UI.Applet
                 avaloniaKeyboardDriver.KeyRelease -= AvaloniaDynamicTextInputHandler_KeyRelease;
                 avaloniaKeyboardDriver.TextInput -= AvaloniaDynamicTextInputHandler_TextInput;
             }
-            
+
             _textChangedSubscription?.Dispose();
             _selectionStartChangedSubscription?.Dispose();
             _selectionEndtextChangedSubscription?.Dispose();

--- a/src/Ryujinx/UI/Applet/ControllerAppletDialog.axaml.cs
+++ b/src/Ryujinx/UI/Applet/ControllerAppletDialog.axaml.cs
@@ -37,8 +37,8 @@ namespace Ryujinx.Ava.UI.Applet
 
         public ControllerAppletDialog(MainWindow mainWindow, ControllerAppletUIArgs args)
         {
-            PlayerCount = args.PlayerCountMin == args.PlayerCountMax 
-                ? args.PlayerCountMin.ToString() 
+            PlayerCount = args.PlayerCountMin == args.PlayerCountMax
+                ? args.PlayerCountMin.ToString()
                 : $"{args.PlayerCountMin} - {args.PlayerCountMax}";
 
             SupportsProController = (args.SupportedStyles & ControllerType.ProController) != 0;
@@ -112,9 +112,11 @@ namespace Ryujinx.Ava.UI.Applet
             {
                 Dispatcher.UIThread.InvokeAsync(async () =>
                 {
-                    _mainWindow.SettingsWindow = new SettingsWindow(_mainWindow.VirtualFileSystem, _mainWindow.ContentManager);
+                    _mainWindow.SettingsWindow =
+                        new SettingsWindow(_mainWindow.VirtualFileSystem, _mainWindow.ContentManager);
                     _mainWindow.SettingsWindow.NavPanel.Content = _mainWindow.SettingsWindow.InputPage;
-                    _mainWindow.SettingsWindow.NavPanel.SelectedItem = _mainWindow.SettingsWindow.NavPanel.MenuItems.ElementAt(1);
+                    _mainWindow.SettingsWindow.NavPanel.SelectedItem =
+                        _mainWindow.SettingsWindow.NavPanel.MenuItems.ElementAt(1);
 
                     await ContentDialogHelper.ShowWindowAsync(_mainWindow.SettingsWindow, _mainWindow);
                     _mainWindow.SettingsWindow = null;
@@ -129,4 +131,3 @@ namespace Ryujinx.Ava.UI.Applet
         }
     }
 }
-

--- a/src/Ryujinx/UI/Controls/ApplicationListView.axaml
+++ b/src/Ryujinx/UI/Controls/ApplicationListView.axaml
@@ -7,6 +7,7 @@
     xmlns:helpers="clr-namespace:Ryujinx.Ava.UI.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:ui="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    xmlns:converters="clr-namespace:Avalonia.Data.Converters;assembly=Avalonia.Base"
     d:DesignHeight="450"
     d:DesignWidth="800"
     Focusable="True"
@@ -110,6 +111,11 @@
                                         Text="{Binding FileExtension}"
                                         TextAlignment="Start"
                                         TextWrapping="Wrap" />
+                                    <TextBlock
+                                        HorizontalAlignment="Stretch"
+                                        Text="{Binding Converter={helpers:MultiplayerInfoConverter}}"
+                                        TextAlignment="Start"
+                                        TextWrapping="Wrap"/>
                                 </StackPanel>
                                 <StackPanel
                                     Grid.Column="4"

--- a/src/Ryujinx/UI/Controls/NavigationDialogHost.axaml.cs
+++ b/src/Ryujinx/UI/Controls/NavigationDialogHost.axaml.cs
@@ -48,7 +48,7 @@ namespace Ryujinx.Ava.UI.Controls
 
             if (contentManager.GetCurrentFirmwareVersion() != null)
                 Task.Run(() => UserFirmwareAvatarSelectorViewModel.PreloadAvatars(contentManager, virtualFileSystem));
-            
+
             InitializeComponent();
         }
 
@@ -60,16 +60,17 @@ namespace Ryujinx.Ava.UI.Controls
             LoadProfiles();
         }
 
-        public void Navigate(Type sourcePageType, object parameter) 
+        public void Navigate(Type sourcePageType, object parameter)
             => ContentFrame.Navigate(sourcePageType, parameter);
 
         public static async Task Show(
-            AccountManager ownerAccountManager, 
+            AccountManager ownerAccountManager,
             ContentManager ownerContentManager,
-            VirtualFileSystem ownerVirtualFileSystem, 
+            VirtualFileSystem ownerVirtualFileSystem,
             HorizonClient ownerHorizonClient)
         {
-            var content = new NavigationDialogHost(ownerAccountManager, ownerContentManager, ownerVirtualFileSystem, ownerHorizonClient);
+            var content = new NavigationDialogHost(ownerAccountManager, ownerContentManager, ownerVirtualFileSystem,
+                ownerHorizonClient);
             ContentDialog contentDialog = new()
             {
                 Title = LocaleManager.Instance[LocaleKeys.UserProfileWindowTitle],
@@ -106,11 +107,13 @@ namespace Ryujinx.Ava.UI.Controls
                 .OrderBy(x => x.Name)
                 .ForEach(profile => ViewModel.Profiles.Add(new UserProfile(profile, this)));
 
-            var saveDataFilter = SaveDataFilter.Make(programId: default, saveType: SaveDataType.Account, default, saveDataId: default, index: default);
+            var saveDataFilter = SaveDataFilter.Make(programId: default, saveType: SaveDataType.Account, default,
+                saveDataId: default, index: default);
 
             using var saveDataIterator = new UniqueRef<SaveDataIterator>();
 
-            HorizonClient.Fs.OpenSaveDataIterator(ref saveDataIterator.Ref, SaveDataSpaceId.User, in saveDataFilter).ThrowIfFailure();
+            HorizonClient.Fs.OpenSaveDataIterator(ref saveDataIterator.Ref, SaveDataSpaceId.User, in saveDataFilter)
+                .ThrowIfFailure();
 
             Span<SaveDataInfo> saveDataInfo = stackalloc SaveDataInfo[10];
 
@@ -138,7 +141,8 @@ namespace Ryujinx.Ava.UI.Controls
 
             foreach (var account in lostAccounts)
             {
-                ViewModel.LostProfiles.Add(new UserProfile(new HLE.HOS.Services.Account.Acc.UserProfile(account, string.Empty, null), this));
+                ViewModel.LostProfiles.Add(
+                    new UserProfile(new HLE.HOS.Services.Account.Acc.UserProfile(account, string.Empty, null), this));
             }
 
             ViewModel.Profiles.Add(new BaseModel());
@@ -155,10 +159,10 @@ namespace Ryujinx.Ava.UI.Controls
 
                 if (profile == null)
                 {
-                    _ = Dispatcher.UIThread.InvokeAsync(async () 
+                    _ = Dispatcher.UIThread.InvokeAsync(async ()
                         => await ContentDialogHelper.CreateErrorDialog(
                             LocaleManager.Instance[LocaleKeys.DialogUserProfileDeletionWarningMessage]));
-                    
+
                     return;
                 }
 

--- a/src/Ryujinx/UI/Helpers/GlyphValueConverter.cs
+++ b/src/Ryujinx/UI/Helpers/GlyphValueConverter.cs
@@ -22,9 +22,9 @@ namespace Ryujinx.Ava.UI.Helpers
             _key = key;
         }
 
-        public string this[string key] => 
+        public string this[string key] =>
             _glyphs.TryGetValue(Enum.Parse<Glyph>(key), out var val)
-                ? val 
+                ? val
                 : string.Empty;
 
         public override object ProvideValue(IServiceProvider serviceProvider) => this[_key];

--- a/src/Ryujinx/UI/Helpers/MultiplayerInfoConverter.cs
+++ b/src/Ryujinx/UI/Helpers/MultiplayerInfoConverter.cs
@@ -1,0 +1,44 @@
+﻿using Avalonia.Data.Converters;
+using Avalonia.Markup.Xaml;
+using Ryujinx.Ava.Common.Locale;
+using Ryujinx.UI.App.Common;
+using Ryujinx.UI.Common.Helper;
+using System;
+using System.Globalization;
+
+namespace Ryujinx.Ava.UI.Helpers
+{
+    internal class MultiplayerInfoConverter : MarkupExtension, IValueConverter
+    {
+        private static readonly MultiplayerInfoConverter _instance = new();
+
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value is ApplicationData applicationData)
+            {
+                if (applicationData.PlayerCount != 0 && applicationData.GameCount != 0)
+                {
+                    return $"Hosted Games: {applicationData.GameCount}\nOnline Players: {applicationData.PlayerCount}";
+                }
+                else
+                {
+                    return "";
+                }
+            }
+            else
+            {
+                return "";
+            }
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return _instance;
+        }
+    }
+}

--- a/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/MainWindowViewModel.cs
@@ -53,6 +53,7 @@ namespace Ryujinx.Ava.UI.ViewModels
     public class MainWindowViewModel : BaseModel
     {
         private const int HotKeyPressDelayMs = 500;
+
         private delegate int LoadContentFromFolderDelegate(List<string> dirs, out int numRemoved);
 
         private ObservableCollectionExtended<ApplicationData> _applications;
@@ -117,8 +118,11 @@ namespace Ryujinx.Ava.UI.ViewModels
         public ApplicationData ListSelectedApplication;
         public ApplicationData GridSelectedApplication;
 
+        public IEnumerable<LdnGameData> LastLdnGameData;
+
         public static readonly Bitmap IconBitmap =
-            new(Assembly.GetAssembly(typeof(ConfigurationState))!.GetManifestResourceStream("Ryujinx.UI.Common.Resources.Logo_Ryujinx.png")!);
+            new(Assembly.GetAssembly(typeof(ConfigurationState))!.GetManifestResourceStream(
+                "Ryujinx.UI.Common.Resources.Logo_Ryujinx.png")!);
 
         public MainWindow Window { get; init; }
 
@@ -173,7 +177,7 @@ namespace Ryujinx.Ava.UI.ViewModels
             SwitchToGameControl = switchToGameControl;
             SetMainContent = setMainContent;
             TopLevel = topLevel;
-            
+
 #if DEBUG
             topLevel.AttachDevTools(new KeyGesture(Avalonia.Input.Key.F12, KeyModifiers.Control));
 #endif
@@ -268,7 +272,7 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public bool ShowFirmwareStatus => !ShowLoadProgress;
 
-        public bool ShowRightmostSeparator 
+        public bool ShowRightmostSeparator
         {
             get => _showRightmostSeparator;
             set
@@ -390,13 +394,18 @@ namespace Ryujinx.Ava.UI.ViewModels
             }
         }
 
-        public bool OpenUserSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() && SelectedApplication.ControlHolder.Value.UserAccountSaveDataSize > 0;
+        public bool OpenUserSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() &&
+                                                    SelectedApplication.ControlHolder.Value.UserAccountSaveDataSize > 0;
 
-        public bool OpenDeviceSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() && SelectedApplication.ControlHolder.Value.DeviceSaveDataSize > 0;
+        public bool OpenDeviceSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() &&
+                                                      SelectedApplication.ControlHolder.Value.DeviceSaveDataSize > 0;
 
-        public bool TrimXCIEnabled => Ryujinx.Common.Utilities.XCIFileTrimmer.CanTrim(SelectedApplication.Path, new Common.XCIFileTrimmerMainWindowLog(this));
-        
-        public bool OpenBcatSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() && SelectedApplication.ControlHolder.Value.BcatDeliveryCacheStorageSize > 0;
+        public bool TrimXCIEnabled => Ryujinx.Common.Utilities.XCIFileTrimmer.CanTrim(SelectedApplication.Path,
+            new Common.XCIFileTrimmerMainWindowLog(this));
+
+        public bool OpenBcatSaveDirectoryEnabled => !SelectedApplication.ControlHolder.ByteSpan.IsZeros() &&
+                                                    SelectedApplication.ControlHolder.Value
+                                                        .BcatDeliveryCacheStorageSize > 0;
 
         public bool CreateShortcutEnabled => !ReleaseInformation.IsFlatHubBuild;
 
@@ -509,7 +518,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 OnPropertyChanged();
             }
         }
-        
+
         public bool StatusBarProgressStatusVisible
         {
             get => _statusBarProgressStatusVisible;
@@ -519,6 +528,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 OnPropertyChanged();
             }
         }
+
         public string StatusBarProgressStatusText
         {
             get => _statusBarProgressStatusText;
@@ -550,7 +560,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 OnPropertyChanged();
             }
         }
-        
+
         public string ShaderCountText
         {
             get => _shaderCountText;
@@ -799,7 +809,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             get => FileAssociationHelper.IsTypeAssociationSupported;
         }
-        
+
         public bool AreMimeTypesRegistered
         {
             get => FileAssociationHelper.AreMimeTypesRegistered;
@@ -833,7 +843,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public bool ShowNames
         {
-            get => ConfigurationState.Instance.UI.ShowNames && ConfigurationState.Instance.UI.GridSize > 1; set
+            get => ConfigurationState.Instance.UI.ShowNames && ConfigurationState.Instance.UI.GridSize > 1;
+            set
             {
                 ConfigurationState.Instance.UI.ShowNames.Value = value;
 
@@ -1013,23 +1024,24 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         #region PrivateMethods
 
-        private static IComparer<ApplicationData> CreateComparer(bool ascending, Func<ApplicationData, IComparable> selector) =>
+        private static IComparer<ApplicationData> CreateComparer(bool ascending,
+            Func<ApplicationData, IComparable> selector) =>
             ascending
                 ? SortExpressionComparer<ApplicationData>.Ascending(selector)
                 : SortExpressionComparer<ApplicationData>.Descending(selector);
 
-        private IComparer<ApplicationData> GetComparer() 
+        private IComparer<ApplicationData> GetComparer()
             => SortMode switch
             {
 #pragma warning disable IDE0055 // Disable formatting
-                ApplicationSort.Title           => CreateComparer(IsAscending, app => app.Name),
-                ApplicationSort.Developer       => CreateComparer(IsAscending, app => app.Developer),
-                ApplicationSort.LastPlayed      => new LastPlayedSortComparer(IsAscending),
+                ApplicationSort.Title => CreateComparer(IsAscending, app => app.Name),
+                ApplicationSort.Developer => CreateComparer(IsAscending, app => app.Developer),
+                ApplicationSort.LastPlayed => new LastPlayedSortComparer(IsAscending),
                 ApplicationSort.TotalTimePlayed => new TimePlayedSortComparer(IsAscending),
-                ApplicationSort.FileType        => CreateComparer(IsAscending, app => app.FileExtension),
-                ApplicationSort.FileSize        => CreateComparer(IsAscending, app => app.FileSize),
-                ApplicationSort.Path            => CreateComparer(IsAscending, app => app.Path),
-                ApplicationSort.Favorite        => CreateComparer(IsAscending, app => new AppListFavoriteComparable(app)),
+                ApplicationSort.FileType => CreateComparer(IsAscending, app => app.FileExtension),
+                ApplicationSort.FileSize => CreateComparer(IsAscending, app => app.FileSize),
+                ApplicationSort.Path => CreateComparer(IsAscending, app => app.Path),
+                ApplicationSort.Favorite => CreateComparer(IsAscending, app => new AppListFavoriteComparable(app)),
                 _ => null,
 #pragma warning restore IDE0055
             };
@@ -1060,7 +1072,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 CompareInfo compareInfo = CultureInfo.CurrentCulture.CompareInfo;
 
-                return compareInfo.IndexOf(app.Name, _searchText, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0;
+                return compareInfo.IndexOf(app.Name, _searchText,
+                    CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0;
             }
 
             return false;
@@ -1074,21 +1087,27 @@ namespace Ryujinx.Ava.UI.ViewModels
 
                 if (firmwareVersion == null)
                 {
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareNotFoundErrorMessage, filename));
+                    await ContentDialogHelper.CreateErrorDialog(
+                        LocaleManager.Instance.UpdateAndGetDynamicValue(
+                            LocaleKeys.DialogFirmwareInstallerFirmwareNotFoundErrorMessage, filename));
 
                     return;
                 }
 
-                string dialogTitle = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallTitle, firmwareVersion.VersionString);
-                string dialogMessage = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallMessage, firmwareVersion.VersionString);
+                string dialogTitle = LocaleManager.Instance.UpdateAndGetDynamicValue(
+                    LocaleKeys.DialogFirmwareInstallerFirmwareInstallTitle, firmwareVersion.VersionString);
+                string dialogMessage = LocaleManager.Instance.UpdateAndGetDynamicValue(
+                    LocaleKeys.DialogFirmwareInstallerFirmwareInstallMessage, firmwareVersion.VersionString);
 
                 SystemVersion currentVersion = ContentManager.GetCurrentFirmwareVersion();
                 if (currentVersion != null)
                 {
-                    dialogMessage += LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSubMessage, currentVersion.VersionString);
+                    dialogMessage += LocaleManager.Instance.UpdateAndGetDynamicValue(
+                        LocaleKeys.DialogFirmwareInstallerFirmwareInstallSubMessage, currentVersion.VersionString);
                 }
 
-                dialogMessage += LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallConfirmMessage];
+                dialogMessage +=
+                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallConfirmMessage];
 
                 UserResult result = await ContentDialogHelper.CreateConfirmationDialog(
                     dialogTitle,
@@ -1097,7 +1116,8 @@ namespace Ryujinx.Ava.UI.ViewModels
                     LocaleManager.Instance[LocaleKeys.InputDialogNo],
                     LocaleManager.Instance[LocaleKeys.RyujinxConfirm]);
 
-                UpdateWaitWindow waitingDialog = new(dialogTitle, LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallWaitMessage]);
+                UpdateWaitWindow waitingDialog = new(dialogTitle,
+                    LocaleManager.Instance[LocaleKeys.DialogFirmwareInstallerFirmwareInstallWaitMessage]);
 
                 if (result == UserResult.Yes)
                 {
@@ -1118,20 +1138,23 @@ namespace Ryujinx.Ava.UI.ViewModels
                             {
                                 waitingDialog.Close();
 
-                                string message = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.DialogFirmwareInstallerFirmwareInstallSuccessMessage, firmwareVersion.VersionString);
+                                string message = LocaleManager.Instance.UpdateAndGetDynamicValue(
+                                    LocaleKeys.DialogFirmwareInstallerFirmwareInstallSuccessMessage,
+                                    firmwareVersion.VersionString);
 
                                 await ContentDialogHelper.CreateInfoDialog(
-                                    dialogTitle, 
-                                    message, 
-                                    LocaleManager.Instance[LocaleKeys.InputDialogOk], 
-                                    string.Empty, 
+                                    dialogTitle,
+                                    message,
+                                    LocaleManager.Instance[LocaleKeys.InputDialogOk],
+                                    string.Empty,
                                     LocaleManager.Instance[LocaleKeys.RyujinxInfo]);
 
                                 Logger.Info?.Print(LogClass.Application, message);
 
                                 // Purge Applet Cache.
 
-                                DirectoryInfo miiEditorCacheFolder = new(Path.Combine(AppDataManager.GamesDirPath, "0100000000001009", "cache"));
+                                DirectoryInfo miiEditorCacheFolder = new(Path.Combine(AppDataManager.GamesDirPath,
+                                    "0100000000001009", "cache"));
 
                                 if (miiEditorCacheFolder.Exists)
                                 {
@@ -1152,10 +1175,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                         {
                             RefreshFirmwareStatus();
                         }
-                    })
-                    {
-                        Name = "GUI.FirmwareInstallerThread",
-                    };
+                    }) { Name = "GUI.FirmwareInstallerThread", };
 
                     thread.Start();
                 }
@@ -1194,11 +1214,13 @@ namespace Ryujinx.Ava.UI.ViewModels
                                 IsLoadingIndeterminate = false;
                                 break;
                             case LoadState.Loaded:
-                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, _currentApplicationData.Name);
+                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading,
+                                    _currentApplicationData.Name);
                                 IsLoadingIndeterminate = true;
                                 CacheLoadStatus = string.Empty;
                                 break;
                         }
+
                         break;
                     case ShaderCacheLoadingState shaderCacheState:
                         CacheLoadStatus = $"{current} / {total}";
@@ -1214,11 +1236,13 @@ namespace Ryujinx.Ava.UI.ViewModels
                                 IsLoadingIndeterminate = false;
                                 break;
                             case ShaderCacheLoadingState.Loaded:
-                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, _currentApplicationData.Name);
+                                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading,
+                                    _currentApplicationData.Name);
                                 IsLoadingIndeterminate = true;
                                 CacheLoadStatus = string.Empty;
                                 break;
                         }
+
                         break;
                     default:
                         throw new ArgumentException($"Unknown Progress Handler type {typeof(T)}");
@@ -1248,7 +1272,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         private void InitializeGame()
         {
             RendererHostControl.WindowCreated += RendererHost_Created;
-            
+
             AppHost.StatusUpdatedEvent += Update_StatusBar;
             AppHost.AppExit += AppHost_AppExit;
 
@@ -1282,8 +1306,8 @@ namespace Ryujinx.Ava.UI.ViewModels
                 Dispatcher.UIThread.InvokeAsync(() =>
                 {
                     Application.Current!.Styles.TryGetResource(args.VSyncEnabled
-                        ? "VsyncEnabled"
-                        : "VsyncDisabled",
+                            ? "VsyncEnabled"
+                            : "VsyncDisabled",
                         Application.Current.ActualThemeVariant,
                         out object color);
 
@@ -1297,9 +1321,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                     GameStatusText = args.GameStatus;
                     VolumeStatusText = args.VolumeStatus;
                     FifoStatusText = args.FifoStatus;
-                    
-                    ShaderCountText = (ShowRightmostSeparator = args.ShaderCount > 0) 
-                        ? $"{LocaleManager.Instance[LocaleKeys.CompilingShaders]}: {args.ShaderCount}" 
+
+                    ShaderCountText = (ShowRightmostSeparator = args.ShaderCount > 0)
+                        ? $"{LocaleManager.Instance[LocaleKeys.CompilingShaders]}: {args.ShaderCount}"
                         : string.Empty;
 
                     ShowStatusSeparator = true;
@@ -1314,12 +1338,12 @@ namespace Ryujinx.Ava.UI.ViewModels
             _rendererWaitEvent.Set();
         }
 
-        private async Task LoadContentFromFolder(LocaleKeys localeMessageAddedKey, LocaleKeys localeMessageRemovedKey, LoadContentFromFolderDelegate onDirsSelected)
+        private async Task LoadContentFromFolder(LocaleKeys localeMessageAddedKey, LocaleKeys localeMessageRemovedKey,
+            LoadContentFromFolderDelegate onDirsSelected)
         {
             var result = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
             {
-                Title = LocaleManager.Instance[LocaleKeys.OpenFolderDialogTitle],
-                AllowMultiple = true,
+                Title = LocaleManager.Instance[LocaleKeys.OpenFolderDialogTitle], AllowMultiple = true,
             });
 
             if (result.Count > 0)
@@ -1327,20 +1351,23 @@ namespace Ryujinx.Ava.UI.ViewModels
                 var dirs = result.Select(it => it.Path.LocalPath).ToList();
                 var numAdded = onDirsSelected(dirs, out int numRemoved);
 
-                var msg = String.Join("\r\n", new string[] {
-                    string.Format(LocaleManager.Instance[localeMessageRemovedKey], numRemoved),
-                    string.Format(LocaleManager.Instance[localeMessageAddedKey], numAdded)
-                });
+                var msg = String.Join("\r\n",
+                    new string[]
+                    {
+                        string.Format(LocaleManager.Instance[localeMessageRemovedKey], numRemoved),
+                        string.Format(LocaleManager.Instance[localeMessageAddedKey], numAdded)
+                    });
 
                 await Dispatcher.UIThread.InvokeAsync(async () =>
                 {
                     await ContentDialogHelper.ShowTextDialog(
-                        LocaleManager.Instance[numAdded > 0 || numRemoved > 0 ? LocaleKeys.RyujinxConfirm : LocaleKeys.RyujinxInfo],
-                        msg, 
-                        string.Empty, 
-                        string.Empty, 
-                        string.Empty, 
-                        LocaleManager.Instance[LocaleKeys.InputDialogOk], 
+                        LocaleManager.Instance[
+                            numAdded > 0 || numRemoved > 0 ? LocaleKeys.RyujinxConfirm : LocaleKeys.RyujinxInfo],
+                        msg,
+                        string.Empty,
+                        string.Empty,
+                        string.Empty,
+                        LocaleManager.Instance[LocaleKeys.InputDialogOk],
                         (int)Symbol.Checkmark);
                 });
             }
@@ -1364,17 +1391,20 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public void LoadConfigurableHotKeys()
         {
-            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUI, out var showUiKey))
+            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.ShowUI,
+                    out var showUiKey))
             {
                 ShowUiKey = new KeyGesture(showUiKey);
             }
 
-            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot, out var screenshotKey))
+            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey(
+                    (Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Screenshot, out var screenshotKey))
             {
                 ScreenshotKey = new KeyGesture(screenshotKey);
             }
 
-            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Pause, out var pauseKey))
+            if (AvaloniaKeyboardMappingHelper.TryGetAvaKey((Key)ConfigurationState.Instance.Hid.Hotkeys.Value.Pause,
+                    out var pauseKey))
             {
                 PauseKey = new KeyGesture(pauseKey);
             }
@@ -1511,7 +1541,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public async Task ManageProfiles()
         {
-            await NavigationDialogHost.Show(AccountManager, ContentManager, VirtualFileSystem, LibHacHorizonManager.RyujinxClient);
+            await NavigationDialogHost.Show(AccountManager, ContentManager, VirtualFileSystem,
+                LibHacHorizonManager.RyujinxClient);
         }
 
         public void SimulateWakeUpMessage()
@@ -1530,22 +1561,18 @@ namespace Ryujinx.Ava.UI.ViewModels
                     new(LocaleManager.Instance[LocaleKeys.AllSupportedFormats])
                     {
                         Patterns = new[] { "*.nsp", "*.xci", "*.nca", "*.nro", "*.nso" },
-                        AppleUniformTypeIdentifiers = new[]
-                        {
-                            "com.ryujinx.nsp",
-                            "com.ryujinx.xci",
-                            "com.ryujinx.nca",
-                            "com.ryujinx.nro",
-                            "com.ryujinx.nso",
-                        },
-                        MimeTypes = new[]
-                        {
-                            "application/x-nx-nsp",
-                            "application/x-nx-xci",
-                            "application/x-nx-nca",
-                            "application/x-nx-nro",
-                            "application/x-nx-nso",
-                        },
+                        AppleUniformTypeIdentifiers =
+                            new[]
+                            {
+                                "com.ryujinx.nsp", "com.ryujinx.xci", "com.ryujinx.nca", "com.ryujinx.nro",
+                                "com.ryujinx.nso",
+                            },
+                        MimeTypes =
+                            new[]
+                            {
+                                "application/x-nx-nsp", "application/x-nx-xci", "application/x-nx-nca",
+                                "application/x-nx-nro", "application/x-nx-nso",
+                            },
                     },
                     new("NSP")
                     {
@@ -1589,7 +1616,8 @@ namespace Ryujinx.Ava.UI.ViewModels
                 }
                 else
                 {
-                    await ContentDialogHelper.CreateErrorDialog(LocaleManager.Instance[LocaleKeys.MenuBarFileOpenFromFileError]);
+                    await ContentDialogHelper.CreateErrorDialog(
+                        LocaleManager.Instance[LocaleKeys.MenuBarFileOpenFromFileError]);
                 }
             }
         }
@@ -1614,8 +1642,7 @@ namespace Ryujinx.Ava.UI.ViewModels
         {
             var result = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
             {
-                Title = LocaleManager.Instance[LocaleKeys.OpenFolderDialogTitle],
-                AllowMultiple = false,
+                Title = LocaleManager.Instance[LocaleKeys.OpenFolderDialogTitle], AllowMultiple = false,
             });
 
             if (result.Count > 0)
@@ -1650,7 +1677,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             Logger.RestartTime();
 
-            SelectedIcon ??= ApplicationLibrary.GetApplicationIcon(application.Path, ConfigurationState.Instance.System.Language, application.Id);
+            SelectedIcon ??= ApplicationLibrary.GetApplicationIcon(application.Path,
+                ConfigurationState.Instance.System.Language, application.Id);
 
             PrepareLoadScreen();
 
@@ -1682,7 +1710,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             if (string.IsNullOrWhiteSpace(application.Name))
             {
-                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading, AppHost.Device.Processes.ActiveApplication.Name);
+                LoadHeading = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.LoadingHeading,
+                    AppHost.Device.Processes.ActiveApplication.Name);
                 application.Name = AppHost.Device.Processes.ActiveApplication.Name;
             }
 
@@ -1704,7 +1733,7 @@ namespace Ryujinx.Ava.UI.ViewModels
                 RendererHostControl.Focus();
             });
 
-        public static void UpdateGameMetadata(string titleId) 
+        public static void UpdateGameMetadata(string titleId)
             => ApplicationLibrary.LoadAndSaveMetaData(titleId, appMetadata => appMetadata.UpdatePostGame());
 
         public void RefreshFirmwareStatus()
@@ -1723,7 +1752,8 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             if (version != null)
             {
-                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarSystemVersion, version.VersionString);
+                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarSystemVersion,
+                    version.VersionString);
 
                 hasApplet = version.Major > 3;
             }
@@ -1834,9 +1864,11 @@ namespace Ryujinx.Ava.UI.ViewModels
             if (ConfigurationState.Instance.Logger.EnableTrace.Value)
             {
                 string mainMessage = LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckLoggingEnabledMessage];
-                string secondaryMessage = LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckLoggingEnabledConfirmMessage];
+                string secondaryMessage =
+                    LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckLoggingEnabledConfirmMessage];
 
-                UserResult result = await ContentDialogHelper.CreateLocalizedConfirmationDialog(mainMessage, secondaryMessage);
+                UserResult result =
+                    await ContentDialogHelper.CreateLocalizedConfirmationDialog(mainMessage, secondaryMessage);
 
                 if (result == UserResult.Yes)
                 {
@@ -1849,9 +1881,11 @@ namespace Ryujinx.Ava.UI.ViewModels
             if (!string.IsNullOrWhiteSpace(ConfigurationState.Instance.Graphics.ShadersDumpPath.Value))
             {
                 string mainMessage = LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckShaderDumpEnabledMessage];
-                string secondaryMessage = LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckShaderDumpEnabledConfirmMessage];
+                string secondaryMessage =
+                    LocaleManager.Instance[LocaleKeys.DialogPerformanceCheckShaderDumpEnabledConfirmMessage];
 
-                UserResult result = await ContentDialogHelper.CreateLocalizedConfirmationDialog(mainMessage, secondaryMessage);
+                UserResult result =
+                    await ContentDialogHelper.CreateLocalizedConfirmationDialog(mainMessage, secondaryMessage);
 
                 if (result == UserResult.Yes)
                 {
@@ -1861,8 +1895,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                 }
             }
         }
-        
-        public async void ProcessTrimResult(String filename, Ryujinx.Common.Utilities.XCIFileTrimmer.OperationOutcome operationOutcome)
+
+        public async void ProcessTrimResult(String filename,
+            Ryujinx.Common.Utilities.XCIFileTrimmer.OperationOutcome operationOutcome)
         {
             string notifyUser = operationOutcome.ToLocalisedText();
             if (notifyUser != null)
@@ -1877,28 +1912,33 @@ namespace Ryujinx.Ava.UI.ViewModels
                 switch (operationOutcome)
                 {
                     case Ryujinx.Common.Utilities.XCIFileTrimmer.OperationOutcome.Successful:
-                        if (Avalonia.Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+                        if (Avalonia.Application.Current.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime
+                            desktop)
                         {
                             if (desktop.MainWindow is MainWindow mainWindow)
                                 mainWindow.LoadApplications();
                         }
+
                         break;
                 }
             }
         }
+
         public async Task TrimXCIFile(string filename)
         {
             if (filename == null)
             {
                 return;
             }
+
             var trimmer = new XCIFileTrimmer(filename, new Common.XCIFileTrimmerMainWindowLog(this));
             if (trimmer.CanBeTrimmed)
             {
                 var savings = (double)trimmer.DiskSpaceSavingsB / 1024.0 / 1024.0;
                 var currentFileSize = (double)trimmer.FileSizeB / 1024.0 / 1024.0;
                 var cartDataSize = (double)trimmer.DataSizeB / 1024.0 / 1024.0;
-                string secondaryText = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.TrimXCIFileDialogSecondaryText, currentFileSize, cartDataSize, savings);
+                string secondaryText = LocaleManager.Instance.UpdateAndGetDynamicValue(
+                    LocaleKeys.TrimXCIFileDialogSecondaryText, currentFileSize, cartDataSize, savings);
                 var result = await ContentDialogHelper.CreateConfirmationDialog(
                     LocaleManager.Instance[LocaleKeys.TrimXCIFileDialogPrimaryText],
                     secondaryText,
@@ -1912,7 +1952,9 @@ namespace Ryujinx.Ava.UI.ViewModels
                     {
                         Dispatcher.UIThread.Post(() =>
                         {
-                            StatusBarProgressStatusText = LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarXCIFileTrimming, Path.GetFileName(filename));
+                            StatusBarProgressStatusText =
+                                LocaleManager.Instance.UpdateAndGetDynamicValue(LocaleKeys.StatusBarXCIFileTrimming,
+                                    Path.GetFileName(filename));
                             StatusBarProgressStatusVisible = true;
                             StatusBarProgressMaximum = 1;
                             StatusBarProgressValue = 0;
@@ -1935,15 +1977,12 @@ namespace Ryujinx.Ava.UI.ViewModels
                                 StatusBarVisible = false;
                             });
                         }
-                    })
-                    {
-                        Name = "GUI.XCIFileTrimmerThread",
-                        IsBackground = true,
-                    };
+                    }) { Name = "GUI.XCIFileTrimmerThread", IsBackground = true, };
                     XCIFileTrimThread.Start();
                 }
             }
         }
+
         #endregion
     }
 }

--- a/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
+++ b/src/Ryujinx/UI/ViewModels/SettingsViewModel.cs
@@ -25,12 +25,13 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using TimeZone = Ryujinx.Ava.UI.Models.TimeZone;
 
 namespace Ryujinx.Ava.UI.ViewModels
 {
-    public class SettingsViewModel : BaseModel
+    public partial class SettingsViewModel : BaseModel
     {
         private readonly VirtualFileSystem _virtualFileSystem;
         private readonly ContentManager _contentManager;
@@ -56,6 +57,8 @@ namespace Ryujinx.Ava.UI.ViewModels
         public event Action SaveSettingsEvent;
         private int _networkInterfaceIndex;
         private int _multiplayerModeIndex;
+        private string _ldnPassphrase;
+        private string _LdnServer;
 
         public int ResolutionScale
         {
@@ -180,9 +183,22 @@ namespace Ryujinx.Ava.UI.ViewModels
 
         public bool IsVulkanSelected => GraphicsBackendIndex == 0;
         public bool UseHypervisor { get; set; }
+        public bool DisableP2P { get; set; }
 
         public string TimeZone { get; set; }
         public string ShaderDumpPath { get; set; }
+        
+        public string LdnPassphrase
+        {
+            get => _ldnPassphrase;
+            set
+            {
+                _ldnPassphrase = value;
+                IsInvalidLdnPassphraseVisible = !ValidateLdnPassphrase(value);
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(IsInvalidLdnPassphraseVisible));
+            }
+        }
 
         public int Language { get; set; }
         public int Region { get; set; }
@@ -273,6 +289,19 @@ namespace Ryujinx.Ava.UI.ViewModels
             {
                 _multiplayerModeIndex = value;
                 ConfigurationState.Instance.Multiplayer.Mode.Value = (MultiplayerMode)_multiplayerModeIndex;
+            }
+        }
+        
+        [GeneratedRegex("Ryujinx-[0-9a-f]{8}")]
+        private static partial Regex LdnPassphraseRegex();
+        public bool IsInvalidLdnPassphraseVisible { get; set; }
+        public string LdnServer
+        {
+            get => _LdnServer;
+            set
+            {
+                _LdnServer = value;
+                OnPropertyChanged();
             }
         }
 
@@ -392,6 +421,11 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             Dispatcher.UIThread.Post(() => OnPropertyChanged(nameof(NetworkInterfaceIndex)));
         }
+        
+        private bool ValidateLdnPassphrase(string passphrase)
+        {
+            return string.IsNullOrEmpty(passphrase) || (passphrase.Length == 16 && LdnPassphraseRegex().IsMatch(passphrase));
+        }
 
         public void ValidateAndSetTimeZone(string location)
         {
@@ -497,6 +531,9 @@ namespace Ryujinx.Ava.UI.ViewModels
             OpenglDebugLevel = (int)config.Logger.GraphicsDebugLevel.Value;
 
             MultiplayerModeIndex = (int)config.Multiplayer.Mode.Value;
+            DisableP2P = config.Multiplayer.DisableP2p.Value;
+            LdnPassphrase = config.Multiplayer.LdnPassphrase.Value;
+            LdnServer = config.Multiplayer.LdnServer.Value;
         }
 
         public void SaveSettings()
@@ -613,6 +650,9 @@ namespace Ryujinx.Ava.UI.ViewModels
 
             config.Multiplayer.LanInterfaceId.Value = _networkInterfaces[NetworkInterfaceList[NetworkInterfaceIndex]];
             config.Multiplayer.Mode.Value = (MultiplayerMode)MultiplayerModeIndex;
+            config.Multiplayer.DisableP2p.Value = DisableP2P;
+            config.Multiplayer.LdnPassphrase.Value = LdnPassphrase;
+            config.Multiplayer.LdnServer.Value = LdnServer;
 
             config.ToFileFormat().SaveConfig(Program.ConfigurationPath);
 

--- a/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml
+++ b/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml
@@ -37,10 +37,56 @@
                             <TextBlock Text="{ext:Locale MultiplayerModeDisabled}" />
                         </ComboBoxItem>
                         <ComboBoxItem>
+                            <TextBlock Text="{ext:Locale MultiplayerModeLdnRyu}" />
+                        </ComboBoxItem>
+                        <ComboBoxItem>
                             <TextBlock Text="{ext:Locale MultiplayerModeLdnMitm}" />
                         </ComboBoxItem>
                     </ComboBox>
+                    <CheckBox Margin="10,0,0,0" IsChecked="{Binding DisableP2P}">
+                        <TextBlock Text="{ext:Locale MultiplayerDisableP2P}"
+                                   ToolTip.Tip="{ext:Locale MultiplayerDisableP2PTooltip}" />
+                    </CheckBox>
                 </StackPanel>
+                <StackPanel Margin="10,0,0,0" Orientation="Horizontal">
+                    <TextBlock VerticalAlignment="Center"
+                               Text="{ext:Locale LdnPassphrase}"
+                               ToolTip.Tip="{ext:Locale LdnPassphraseTooltip}"
+                               Width="200" />
+                    <TextBox Name="LdnPassphrase"
+                             Text="{Binding LdnPassphrase}"
+                             Width="250"
+                             MaxLength="16"
+                             ToolTip.Tip="{ext:Locale LdnPassphraseInputTooltip}"
+                             Watermark="{ext:Locale LdnPassphraseInputPublic}" />
+                    <Button
+                        Name="GenLdnPassButton"
+                        Grid.Column="1"
+                        MinWidth="90"
+                        Margin="10,0,0,0"
+                        ToolTip.Tip="{ext:Locale GenLdnPassTooltip}"
+                        Click="GenLdnPassButton_OnClick">
+                        <TextBlock HorizontalAlignment="Center"
+                                   Text="{ext:Locale GenLdnPass}" />
+                    </Button>
+                    <Button
+                        Name="ClearLdnPassButton"
+                        Grid.Column="1"
+                        MinWidth="90"
+                        Margin="10,0,0,0"
+                        ToolTip.Tip="{ext:Locale ClearLdnPassTooltip}"
+                        Click="ClearLdnPassButton_OnClick">
+                        <TextBlock HorizontalAlignment="Center"
+                                   Text="{ext:Locale ClearLdnPass}" />
+                    </Button>
+                </StackPanel>
+                <TextBlock  Margin="10,0,0,0"
+                            VerticalAlignment="Center"
+                            Name="InvalidLdnPassphraseBlock"
+                            FontStyle="Italic"
+                            IsVisible="{Binding IsInvalidLdnPassphraseVisible}"
+                            Focusable="False"
+                            Text="{ext:Locale InvalidLdnPassphrase}" />
                 <Separator Height="1" />
                 <TextBlock Classes="h1" Text="{ext:Locale SettingsTabNetworkConnection}" />
                 <CheckBox Margin="10,0,0,0" IsChecked="{Binding EnableInternetAccess}">

--- a/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml.cs
+++ b/src/Ryujinx/UI/Views/Settings/SettingsNetworkView.axaml.cs
@@ -1,12 +1,28 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Ryujinx.Ava.UI.ViewModels;
+using System;
 
 namespace Ryujinx.Ava.UI.Views.Settings
 {
     public partial class SettingsNetworkView : UserControl
     {
+        public SettingsViewModel ViewModel;
+
         public SettingsNetworkView()
         {
             InitializeComponent();
+        }
+        
+        private void GenLdnPassButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            byte[] code = new byte[4];
+            new Random().NextBytes(code);
+            ViewModel.LdnPassphrase = $"Ryujinx-{BitConverter.ToUInt32(code):x8}";
+        }
+        private void ClearLdnPassButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            ViewModel.LdnPassphrase = "";
         }
     }
 }

--- a/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/MainWindow.axaml.cs
@@ -28,6 +28,7 @@ using Ryujinx.UI.Common.Configuration;
 using Ryujinx.UI.Common.Helper;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Runtime.Versioning;
 using System.Threading;
@@ -151,6 +152,34 @@ namespace Ryujinx.Ava.UI.Windows
                     StatusBarView.LoadProgressBar.IsVisible = false;
                 }
             });
+        }
+        
+        private void ApplicationLibrary_LdnGameDataReceived(object sender, LdnGameDataReceivedEventArgs e)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                var ldnGameDataArray = e.LdnData;
+                ViewModel.LastLdnGameData = ldnGameDataArray;
+                foreach (var application in ViewModel.Applications)
+                {
+                    UpdateApplicationWithLdnData(application);
+                }
+                ViewModel.RefreshView();
+            });
+        }
+        private void UpdateApplicationWithLdnData(ApplicationData application)
+        {
+            if (application.ControlHolder.ByteSpan.Length > 0 && ViewModel.LastLdnGameData != null)
+            {
+                IEnumerable<LdnGameData> ldnGameData = ViewModel.LastLdnGameData.Where(game => application.ControlHolder.Value.LocalCommunicationId.Items.Contains(Convert.ToUInt64(game.TitleId, 16)));
+                application.PlayerCount = ldnGameData.Sum(game => game.PlayerCount);
+                application.GameCount = ldnGameData.Count();
+            }
+            else
+            {
+                application.PlayerCount = 0;
+                application.GameCount = 0;
+            }
         }
 
         public void Application_Opened(object sender, ApplicationOpenedEventArgs args)
@@ -468,7 +497,18 @@ namespace Ryujinx.Ava.UI.Windows
                     .Connect()
                     .ObserveOn(SynchronizationContext.Current!)
                     .Bind(ViewModel.Applications)
+                    .OnItemAdded(UpdateApplicationWithLdnData)
                     .Subscribe();
+            ApplicationLibrary.LdnGameDataReceived += ApplicationLibrary_LdnGameDataReceived;
+            ConfigurationState.Instance.Multiplayer.Mode.Event += (sender, evt) =>
+            {
+                _ = Task.Run(ViewModel.ApplicationLibrary.RefreshLdn);
+            };
+            ConfigurationState.Instance.Multiplayer.LdnServer.Event += (sender, evt) =>
+            {
+                _ = Task.Run(ViewModel.ApplicationLibrary.RefreshLdn);
+            };
+            _ = Task.Run(ViewModel.ApplicationLibrary.RefreshLdn);
 
             ViewModel.RefreshFirmwareStatus();
 
@@ -477,7 +517,6 @@ namespace Ryujinx.Ava.UI.Windows
             {
                 LoadApplications();
             }
-            
             _ = CheckLaunchState();
         }
 
@@ -607,13 +646,26 @@ namespace Ryujinx.Ava.UI.Windows
         {
             switch (fileType)
             {
-                case "NSP": ConfigurationState.Instance.UI.ShownFileTypes.NSP.Toggle(); break;
-                case "PFS0": ConfigurationState.Instance.UI.ShownFileTypes.PFS0.Toggle(); break;
-                case "XCI": ConfigurationState.Instance.UI.ShownFileTypes.XCI.Toggle(); break;
-                case "NCA": ConfigurationState.Instance.UI.ShownFileTypes.NCA.Toggle(); break;
-                case "NRO": ConfigurationState.Instance.UI.ShownFileTypes.NRO.Toggle(); break;
-                case "NSO": ConfigurationState.Instance.UI.ShownFileTypes.NSO.Toggle(); break;
-                default: throw new ArgumentOutOfRangeException(fileType);
+                case "NSP":
+                    ConfigurationState.Instance.UI.ShownFileTypes.NSP.Toggle();
+                    break;
+                case "PFS0":
+                    ConfigurationState.Instance.UI.ShownFileTypes.PFS0.Toggle();
+                    break;
+                case "XCI":
+                    ConfigurationState.Instance.UI.ShownFileTypes.XCI.Toggle();
+                    break;
+                case "NCA":
+                    ConfigurationState.Instance.UI.ShownFileTypes.NCA.Toggle();
+                    break;
+                case "NRO":
+                    ConfigurationState.Instance.UI.ShownFileTypes.NRO.Toggle();
+                    break;
+                case "NSO":
+                    ConfigurationState.Instance.UI.ShownFileTypes.NSO.Toggle();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(fileType);
             }
 
             ConfigurationState.Instance.ToFileFormat().SaveConfig(Program.ConfigurationPath);

--- a/src/Ryujinx/UI/Windows/SettingsWindow.axaml.cs
+++ b/src/Ryujinx/UI/Windows/SettingsWindow.axaml.cs
@@ -80,6 +80,7 @@ namespace Ryujinx.Ava.UI.Windows
                         NavPanel.Content = AudioPage;
                         break;
                     case "NetworkPage":
+                        NetworkPage.ViewModel = ViewModel;
                         NavPanel.Content = NetworkPage;
                         break;
                     case "LoggingPage":


### PR DESCRIPTION
* For `RyuLDN` implementation. These changes allow players to matchmake for local wireless using a LDN server. The network implementation originates from Berry's public TCP RyuLDN fork. Additionally displays LDN game status in the game selection window when RyuLDN is enabled. Functionality is only enabled while network mode is set to 'RyuLDN' in the settings.
* Upgraded packages version without affecting current implementation
* Fix unit tests due to packages upgrade